### PR TITLE
소셜 회원가입/탈퇴 1차 구현

### DIFF
--- a/DutchiePay/build.gradle
+++ b/DutchiePay/build.gradle
@@ -34,6 +34,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // h2
+    runtimeOnly 'com.h2database:h2'
 
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/oauth/controller/OauthController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/oauth/controller/OauthController.java
@@ -1,4 +1,18 @@
 package dutchiepay.backend.domain.oauth.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
 public class OauthController {
+    @Operation(summary = "소셜 로그인(구현중)")
+    @GetMapping("/oauth/signup")
+    public String signup(@RequestParam String type) {
+
+        System.out.println("Type: " + type);
+        System.out.println("Redirecting..." );
+        return "redirect:/oauth2/authorization/" + type;
+    }
+
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/oauth/controller/OauthController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/oauth/controller/OauthController.java
@@ -1,18 +1,41 @@
 package dutchiepay.backend.domain.oauth.controller;
 
+import dutchiepay.backend.global.oauth.service.CustomOAuth2UserService;
+import dutchiepay.backend.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 @Controller
+@RequestMapping("/oauth")
+@RequiredArgsConstructor
 public class OauthController {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+
     @Operation(summary = "소셜 로그인(구현중)")
-    @GetMapping("/oauth/signup")
+    @GetMapping("/signup")
     public String signup(@RequestParam String type) {
 
-        System.out.println("Type: " + type);
-        System.out.println("Redirecting..." );
         return "redirect:/oauth2/authorization/" + type;
+    }
+
+    @Operation(summary = "소셜 회원 탈퇴(구현중)")
+    @GetMapping
+    public String unlink(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam String type){
+        if (type.equals("kakao")) {
+            customOAuth2UserService.deleteKakaoUser(userDetails);
+        } else {
+            customOAuth2UserService.deleteNaverUser(userDetails);
+        }
+
+        return "redirect:/";
     }
 
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/oauth/controller/OauthController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/oauth/controller/OauthController.java
@@ -27,7 +27,7 @@ public class OauthController {
     }
 
     @Operation(summary = "소셜 회원 탈퇴(구현중)")
-    @GetMapping
+    @DeleteMapping
     public String unlink(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam String type){
         if (type.equals("kakao")) {
             customOAuth2UserService.deleteKakaoUser(userDetails);

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserDto.java
@@ -1,4 +1,0 @@
-package dutchiepay.backend.domain.user.dto;
-
-public class UserDto {
-}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserLoginResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserLoginResponseDto.java
@@ -1,0 +1,33 @@
+package dutchiepay.backend.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dutchiepay.backend.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserLoginResponseDto {
+
+    private Long userId;
+    private String type;
+    private String nickname;
+    private String profileImg;
+    private String location;
+    private String access;
+    private String refresh;
+    @JsonProperty("isCertified")
+    private boolean certified;
+
+    public static UserLoginResponseDto toDto(User user, String access) {
+        return UserLoginResponseDto.builder()
+                .userId(user.getUserId())
+                .type(user.getOauthProvider())
+                .nickname(user.getNickname())
+                .profileImg(user.getProfileImg())
+                .location(user.getLocation())
+                .access(access)
+                .refresh(user.getRefreshToken())
+                .certified(user.getPhone() != null).build();
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/repository/UserRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/repository/UserRepository.java
@@ -4,12 +4,15 @@ import dutchiepay.backend.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByPhone(String phone);
 
     Optional<User> findByEmail(String email);
 
     boolean existsByNickname(String nickname);
+    Optional<User> findByOauthId(String email);
 
     Optional<User> findByNickname(String username);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/User.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/User.java
@@ -30,7 +30,7 @@ public class User extends Auditing {
     private String email;
 
     //성함
-    @Column(length = 5)
+    @Column(length = 10)
     private String username;
 
     //휴대폰 번호
@@ -103,5 +103,19 @@ public class User extends Auditing {
 
     public void createRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
+    }
+
+    public void delete() {
+        super.delete();
+        // TODO 닉네임은? 지역은?
+        this.phone = null;
+        this.password = null;
+        this.zipCode = null;
+        this.address = null;
+        this.detail = null;
+        this.refreshToken = null;
+        this.profileImg = null;
+        this.state = 2;
+        this.oauthId = null;
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/User.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/User.java
@@ -70,7 +70,6 @@ public class User extends Auditing {
     private int state;
 
     //소셜 ID
-    @Column(length = 20)
     private String oauthId;
 
     //소셜 종류

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/config/Auditing.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/config/Auditing.java
@@ -23,4 +23,8 @@ public abstract class Auditing {
     private LocalDateTime updatedAt;
 
     private LocalDateTime deletedAt;
+
+    public void delete(){
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/config/SecurityConfig.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package dutchiepay.backend.global.config;
 
+import dutchiepay.backend.domain.user.repository.UserRepository;
+import dutchiepay.backend.global.jwt.JwtUtil;
+import dutchiepay.backend.global.security.JwtAuthenticationFilter;
 import dutchiepay.backend.global.security.JwtVerificationFilter;
 import dutchiepay.backend.global.security.NicknameQueryParamFilter;
 import dutchiepay.backend.global.security.UserDetailsServiceImpl;
@@ -30,8 +33,6 @@ import java.util.List;
 @EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
-    private final CustomOAuth2UserService customOauth2UserService;
 
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
@@ -47,7 +48,10 @@ public class SecurityConfig {
             "/users/email",
             "/users/pwd-nonuser",
             "/users/auth",
-            "/users/test"
+            "/users/test",
+            "/oauth/signup",
+            "/index",
+            "/oauth2"
     };
 
     private final String[] readOnlyUrl = {

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/config/SecurityConfig.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/config/SecurityConfig.java
@@ -1,7 +1,10 @@
 package dutchiepay.backend.global.config;
 
+import dutchiepay.backend.global.oauth.handler.CustomOAuth2SuccessHandler;
+import dutchiepay.backend.global.oauth.service.CustomOAuth2UserService;
 import dutchiepay.backend.domain.user.repository.UserRepository;
 import dutchiepay.backend.global.jwt.JwtUtil;
+import dutchiepay.backend.global.jwt.RefreshTokenRepository;
 import dutchiepay.backend.global.security.JwtAuthenticationFilter;
 import dutchiepay.backend.global.security.JwtVerificationFilter;
 import dutchiepay.backend.global.security.NicknameQueryParamFilter;
@@ -33,6 +36,8 @@ import java.util.List;
 @EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
+    private final CustomOAuth2UserService customOauth2UserService;
 
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository;

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/config/SecurityConfig.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package dutchiepay.backend.global.config;
 
 import dutchiepay.backend.domain.user.repository.UserRepository;
 import dutchiepay.backend.global.jwt.JwtUtil;
+import dutchiepay.backend.global.oauth.handler.CustomOAuth2SuccessHandler;
 import dutchiepay.backend.global.security.JwtAuthenticationFilter;
 import dutchiepay.backend.global.security.JwtVerificationFilter;
 import dutchiepay.backend.global.security.NicknameQueryParamFilter;
@@ -37,6 +38,7 @@ public class SecurityConfig {
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
     private final UserDetailsServiceImpl userDetailsService;
+    private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
 
     @Value("${spring.cors.allowed-origins}")
     private List<String> corsOrigins;
@@ -50,8 +52,7 @@ public class SecurityConfig {
             "/users/auth",
             "/users/test",
             "/oauth/signup",
-            "/index",
-            "/oauth2"
+            "/oauth"
     };
 
     private final String[] readOnlyUrl = {
@@ -97,6 +98,8 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.GET, readOnlyUrl).permitAll()
                     .requestMatchers(permitAllUrl).permitAll()
                     .anyRequest().authenticated())
+            .oauth2Login(oauth2 ->
+                    oauth2.successHandler(customOAuth2SuccessHandler))
             .addFilterBefore(new NicknameQueryParamFilter(),
                 UsernamePasswordAuthenticationFilter.class)
             .addFilterBefore(jwtVerificationFilter(), JwtAuthenticationFilter.class)

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/dto/CustomOAuth2User.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/dto/CustomOAuth2User.java
@@ -1,0 +1,23 @@
+package dutchiepay.backend.global.oauth.dto;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User extends DefaultOAuth2User {
+    private final Long userId;
+    private final String oauthId;
+    private final String oauthProvider;
+
+    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities, Map<String, Object> attributes, String nameAttributeKey,
+                            Long userId, String oauthId, String oauthProvider) {
+        super(authorities, attributes, nameAttributeKey);
+        this.userId = userId;
+        this.oauthId = oauthId;
+        this.oauthProvider = oauthProvider;
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/dto/OAuthAttribute.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/dto/OAuthAttribute.java
@@ -44,7 +44,7 @@ public class OAuthAttribute {
                 .email(kakaoAccount.get("email").toString())
                 .nickname("test")
                 .oauthId(attributes.get("id").toString())
-                .oauthProvider("KAKAO")
+                .oauthProvider("kakao")
                 .attributes(attributes)
                 .nameAttributeKey(userNameAttributeName)
                 .build();
@@ -58,7 +58,7 @@ public class OAuthAttribute {
                 .email(response.get("email").toString())
                 .nickname("Navest")
                 .oauthId(response.get("id").toString())
-                .oauthProvider("NAVER")
+                .oauthProvider("naver")
                 .attributes(attributes)
                 .nameAttributeKey(userNameAttributeName)
                 .build();

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/dto/OAuthAttribute.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/dto/OAuthAttribute.java
@@ -1,0 +1,65 @@
+package dutchiepay.backend.global.oauth.dto;
+
+import dutchiepay.backend.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+
+@Slf4j
+@Getter
+public class OAuthAttribute {
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private Long userId;
+    private String email;
+    private String nickname;
+    private String oauthId;
+    private String oauthProvider;
+
+    @Builder
+    public OAuthAttribute(Map<String, Object> attributes, String nameAttributeKey, Long userId, String email, String nickname, String oauthId, String oauthProvider) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.userId = userId;
+        this.email = email;
+        this.nickname = nickname;
+        this.oauthId = oauthId;
+        this.oauthProvider = oauthProvider;
+    }
+
+    public static OAuthAttribute of(String userNameAttributeName, Map<String, Object> attributes, String registrationId) {
+        return switch (registrationId) {
+            case "kakao" -> ofKakao(userNameAttributeName, attributes);
+            default -> null;
+        };
+    }
+
+    public static OAuthAttribute ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+
+        return OAuthAttribute.builder()
+                .email(kakaoAccount.get("email").toString())
+                .nickname("test")
+                .oauthId(attributes.get("id").toString())
+                .oauthProvider("KAKAO")
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    public User toEntity() {
+        // 닉네임 자동생성 필요?
+
+        return User.builder()
+                .email(email)
+                .username(nickname)
+                .nickname(nickname)
+                .location("서울시 중구")
+                .state(0)
+                .oauthId(oauthId)
+                .oauthProvider(oauthProvider)
+                .build();
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/dto/OAuthAttribute.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/dto/OAuthAttribute.java
@@ -32,6 +32,7 @@ public class OAuthAttribute {
     public static OAuthAttribute of(String userNameAttributeName, Map<String, Object> attributes, String registrationId) {
         return switch (registrationId) {
             case "kakao" -> ofKakao(userNameAttributeName, attributes);
+            case "naver" -> ofNaver(userNameAttributeName, attributes);
             default -> null;
         };
     }
@@ -44,6 +45,20 @@ public class OAuthAttribute {
                 .nickname("test")
                 .oauthId(attributes.get("id").toString())
                 .oauthProvider("KAKAO")
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    private static OAuthAttribute ofNaver(String userNameAttributeName, Map<String, Object> attributes) {
+
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        return OAuthAttribute.builder()
+                .email(response.get("email").toString())
+                .nickname("Navest")
+                .oauthId(response.get("id").toString())
+                .oauthProvider("NAVER")
                 .attributes(attributes)
                 .nameAttributeKey(userNameAttributeName)
                 .build();

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/handler/CustomOAuth2SuccessHandler.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/handler/CustomOAuth2SuccessHandler.java
@@ -1,0 +1,29 @@
+package dutchiepay.backend.global.oauth.handler;
+
+import dutchiepay.backend.global.oauth.dto.CustomOAuth2User;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+
+        log.info("Oauth2 login success: User@{}", oAuth2User.getUserId());
+
+        // 유저 데이터 기반으로 토큰 발급
+
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/handler/CustomOAuth2SuccessHandler.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/handler/CustomOAuth2SuccessHandler.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
@@ -24,6 +25,7 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
         log.info("Oauth2 login success: User@{}", oAuth2User.getUserId());
 
         // 유저 데이터 기반으로 토큰 발급
+
 
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/handler/CustomOAuth2SuccessHandler.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/handler/CustomOAuth2SuccessHandler.java
@@ -1,31 +1,66 @@
 package dutchiepay.backend.global.oauth.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dutchiepay.backend.domain.user.dto.UserLoginResponseDto;
+import dutchiepay.backend.domain.user.exception.UserErrorCode;
+import dutchiepay.backend.domain.user.exception.UserErrorException;
+import dutchiepay.backend.domain.user.repository.UserRepository;
+import dutchiepay.backend.entity.User;
+import dutchiepay.backend.global.jwt.JwtUtil;
 import dutchiepay.backend.global.oauth.dto.CustomOAuth2User;
+import dutchiepay.backend.global.security.JwtAuthenticationFilter;
+import dutchiepay.backend.global.security.JwtVerificationFilter;
+import dutchiepay.backend.global.security.UserDetailsImpl;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.Optional;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
-        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        UserDetailsImpl oAuth2User = (UserDetailsImpl) authentication.getPrincipal();
 
         log.info("Oauth2 login success: User@{}", oAuth2User.getUserId());
 
         // 유저 데이터 기반으로 토큰 발급
+        // 사용자한테 토큰 정보가 없으면 access, refresh 발급, refresh가 유효하고 access가 무효하면 access 발급, 둘다 무효하면 둘다 발급
+        User user = userRepository.findById(oAuth2User.getUserId()).orElseThrow(() -> new UserErrorException(UserErrorCode.USER_NOT_FOUND));
 
+        String accessToken = jwtUtil.createAccessToken(oAuth2User.getUserId());
+        String refreshToken = jwtUtil.createRefreshToken(oAuth2User.getUserId());
 
+        user.createRefreshToken(refreshToken);
+        userRepository.save(user);
+
+        sendResponse(response, UserLoginResponseDto.toDto(user, accessToken));
+    }
+
+    private void sendResponse(HttpServletResponse response, UserLoginResponseDto userLoginResponseDto) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_OK);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        ObjectNode rootNode = objectMapper.valueToTree(userLoginResponseDto);
+
+        objectMapper.writeValue(response.getWriter(), rootNode);
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/service/CustomOAuth2UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/service/CustomOAuth2UserService.java
@@ -1,0 +1,64 @@
+package dutchiepay.backend.global.oauth.service;
+
+import dutchiepay.backend.domain.user.repository.UserRepository;
+import dutchiepay.backend.entity.User;
+import dutchiepay.backend.global.oauth.dto.CustomOAuth2User;
+import dutchiepay.backend.global.oauth.dto.OAuthAttribute;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        OAuthAttribute oAuthAttribute = OAuthAttribute.of(userNameAttributeName, oAuth2User.getAttributes(), registrationId);
+
+        User user = saveOrUpdate(oAuthAttribute);
+
+        return new CustomOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+                oAuthAttribute.getAttributes(),
+                oAuthAttribute.getNameAttributeKey(),
+                user.getUserId(),
+                user.getOauthId(),
+                user.getOauthProvider()
+        );
+    }
+
+    private User saveOrUpdate(OAuthAttribute oAuthAttribute) {
+        User user = userRepository.findByOauthId(oAuthAttribute.getEmail())
+                .orElse(oAuthAttribute.toEntity());
+
+        if (!user.getOauthProvider().equals(oAuthAttribute.getOauthProvider())) {
+            User otherAccount = User.builder()
+                    .email(oAuthAttribute.getEmail())
+                    .nickname(user.getNickname())
+                    .oauthId(oAuthAttribute.getOauthId())
+                    .oauthProvider(oAuthAttribute.getOauthProvider())
+                    .build();
+            return userRepository.save(otherAccount);
+        }
+
+        return userRepository.save(user);
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/service/CustomOAuth2UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/service/CustomOAuth2UserService.java
@@ -1,18 +1,33 @@
 package dutchiepay.backend.global.oauth.service;
 
+import dutchiepay.backend.domain.user.exception.UserErrorCode;
+import dutchiepay.backend.domain.user.exception.UserErrorException;
 import dutchiepay.backend.domain.user.repository.UserRepository;
 import dutchiepay.backend.entity.User;
 import dutchiepay.backend.global.oauth.dto.CustomOAuth2User;
 import dutchiepay.backend.global.oauth.dto.OAuthAttribute;
+import dutchiepay.backend.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.Collections;
 
@@ -21,9 +36,17 @@ import java.util.Collections;
 @RequiredArgsConstructor
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
     private final UserRepository userRepository;
+    private final OAuth2AuthorizedClientService oauthService;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
+    private String naverClientId;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+    private String naverClientSecret;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        System.out.println("========Load User=========");
         OAuth2UserService delegate = new DefaultOAuth2UserService();
         OAuth2User oAuth2User = delegate.loadUser(userRequest);
 
@@ -35,18 +58,11 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         User user = saveOrUpdate(oAuthAttribute);
 
-        return new CustomOAuth2User(
-                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
-                oAuthAttribute.getAttributes(),
-                oAuthAttribute.getNameAttributeKey(),
-                user.getUserId(),
-                user.getOauthId(),
-                user.getOauthProvider()
-        );
+        return new UserDetailsImpl(user, oAuth2User.getAttributes());
     }
 
     private User saveOrUpdate(OAuthAttribute oAuthAttribute) {
-        User user = userRepository.findByOauthId(oAuthAttribute.getEmail())
+        User user = userRepository.findByEmail(oAuthAttribute.getEmail())
                 .orElse(oAuthAttribute.toEntity());
 
         if (!user.getOauthProvider().equals(oAuthAttribute.getOauthProvider())) {
@@ -59,6 +75,74 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
             return userRepository.save(otherAccount);
         }
 
-        return userRepository.save(user);
+        return user;
+    }
+
+    @Transactional
+    public void deleteKakaoUser(UserDetailsImpl userDetails) {
+        OAuth2AuthorizedClient authorizedClient = oauthService.loadAuthorizedClient(
+                "kakao", // OAuth2 로그인 제공자 이름 (예: "google", "naver")
+                userDetails.getUsername() // 현재 인증된 사용자
+        );
+        String kakaoAccess = null;
+        if (authorizedClient != null) {
+            kakaoAccess = authorizedClient.getAccessToken().getTokenValue();// Access Token 추출
+        }
+        RestTemplate restTemplate = new RestTemplate();
+
+        // POST 요청으로 데이터 전송
+        // HttpHeaders 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + kakaoAccess); // Authorization 헤더 설정
+
+        // HttpEntity에 본문 없이 헤더만 담기
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        // POST 요청 보내기 (request body 없음)
+        ResponseEntity<String> response = restTemplate.exchange(
+                "https://kapi.kakao.com/v1/user/unlink",  // 요청할 URL
+                HttpMethod.POST,                 // HTTP 메서드
+                entity,                          // HttpEntity (본문 없음, 헤더만 있음)
+                String.class                     // 응답 타입
+        );
+
+        // 결과 출력
+        System.out.println(response.getBody());
+
+        userRepository.findByEmail(userDetails.getEmail())
+                .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_EMAIL_NOT_FOUND)).delete();
+    }
+
+    @Transactional
+    public void deleteNaverUser(UserDetailsImpl userDetails) {
+
+        OAuth2AuthorizedClient authorizedClient = oauthService.loadAuthorizedClient(
+                "naver", // OAuth2 로그인 제공자 이름 (예: "google", "naver")
+                userDetails.getUsername() // 현재 인증된 사용자
+        );
+        System.out.println("get Principal Name: " + authorizedClient.getPrincipalName());
+
+        String naverAccess = null;
+        if (authorizedClient != null) {
+            naverAccess = authorizedClient.getAccessToken().getTokenValue();// Access Token 추출
+        }
+        RestTemplate restTemplate = new RestTemplate();
+
+        // POST 요청으로 데이터 전송
+        String data = "?client_id=" + naverClientId +
+                "&client_secret=" + naverClientSecret +
+                "&access_token=" + naverAccess +
+                "&service_provider=NAVER" +
+                "&grant_type=delete";
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                "https://nid.naver.com/oauth2.0/token" + data,  // 요청할 URL
+                HttpMethod.POST,                 // HTTP 메서드
+                null,                          // HttpEntity
+                String.class                     // 응답 타입
+        );
+
+        userRepository.findByEmail(userDetails.getEmail())
+                .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_EMAIL_NOT_FOUND)).delete();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/service/CustomOAuth2UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/service/CustomOAuth2UserService.java
@@ -46,7 +46,6 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        System.out.println("========Load User=========");
         OAuth2UserService delegate = new DefaultOAuth2UserService();
         OAuth2User oAuth2User = delegate.loadUser(userRequest);
 
@@ -106,9 +105,6 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                 String.class                     // 응답 타입
         );
 
-        // 결과 출력
-        System.out.println(response.getBody());
-
         userRepository.findByEmail(userDetails.getEmail())
                 .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_EMAIL_NOT_FOUND)).delete();
     }
@@ -120,7 +116,6 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                 "naver", // OAuth2 로그인 제공자 이름 (예: "google", "naver")
                 userDetails.getUsername() // 현재 인증된 사용자
         );
-        System.out.println("get Principal Name: " + authorizedClient.getPrincipalName());
 
         String naverAccess = null;
         if (authorizedClient != null) {

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/security/UserDetailsImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/security/UserDetailsImpl.java
@@ -2,17 +2,28 @@ package dutchiepay.backend.global.security;
 
 import dutchiepay.backend.entity.User;
 import java.util.Collection;
+import java.util.Map;
+
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 @Getter
-public class UserDetailsImpl implements UserDetails {
+public class UserDetailsImpl implements OAuth2User, UserDetails {
+    private User user;
+    private Map<String, Object> attributes;
 
-    private final User user;
+    // 소셜 로그인 사용 시 attributes가 있을 수 있음
+    public UserDetailsImpl(User user, Map<String, Object> attributes) {
+        this.user = user;
+        this.attributes = attributes;
+    }
 
+    // 일반 로그인일 때 attributes는 null일 수 있음
     public UserDetailsImpl(User user) {
         this.user = user;
+        this.attributes = null;  // 일반 로그인에서는 null
     }
 
     @Override
@@ -27,7 +38,7 @@ public class UserDetailsImpl implements UserDetails {
     public String getEmail() {
         return user.getEmail();
     }
-    
+
     @Override
     public String getPassword() {
         return user.getPassword();
@@ -57,4 +68,15 @@ public class UserDetailsImpl implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;  // 소셜 로그인이 아니면 null이 반환될 수 있음
+    }
+
+    @Override
+    public String getName() {
+        return user.getUserId().toString();
+    }
+
 }

--- a/DutchiePay/src/main/resources/application.yml
+++ b/DutchiePay/src/main/resources/application.yml
@@ -43,3 +43,49 @@ jwt:
   refresh:
     token:
       expiration: 604800000  # 7일
+
+spring:
+  security:
+    oauth2:
+      client:
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-info-authentication-method: header
+            user-name-attribute: id
+        registration:
+            kakao:
+                client-id: ${KAKAO_CLIENT_ID}
+                client-secret: ${KAKAO_CLIENT_SECRET}
+                redirect-uri: ${KAKAO_REDIRECT_URI}
+                client-name: kakao
+                client-authentication-method: client_secret_post
+                authorization-grant-type: authorization_code
+                scope:
+                  - account_email
+  sms:
+    api-key: ${SMS_API_KEY}
+    api-secret: ${SMS_API_SECRET}
+    provider: https://api.coolsms.co.kr
+    sender: ${SMS_SENDER}
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:tcp://localhost/~/test # h2로 작업하실거면 본인 주소에 맞게 변경해서 사용해주세요!
+    username: sa
+  jpa:
+    hibernate:
+      ddl-auto: create
+
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /swagger
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+  api-docs:
+    groups:
+      enabled: true

--- a/DutchiePay/src/main/resources/application.yml
+++ b/DutchiePay/src/main/resources/application.yml
@@ -1,14 +1,52 @@
 spring:
+  security:
+    oauth2:
+      client:
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-info-authentication-method: header
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-info-authentication-method: header
+            user-name-attribute: response
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: ${KAKAO_REDIRECT_URI}
+            client-name: kakao
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            scope:
+              - account_email
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            redirect-uri: ${NAVER_REDIRECT_URI}
+            client-name: Naver
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            scope:
+              - email
+              - mobile
   sms:
     api-key: ${SMS_API_KEY}
     api-secret: ${SMS_API_SECRET}
     provider: https://api.coolsms.co.kr
     sender: ${SMS_SENDER}
+
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
     url: ${DB_URL}
     username: ${DB_USER}
     password: ${DB_PASSWORD}
+
   jpa:
     database: mysql
     open-in-view: false
@@ -43,94 +81,3 @@ jwt:
   refresh:
     token:
       expiration: 604800000  # 7일
-
-spring:
-  security:
-    oauth2:
-      client:
-        provider:
-          kakao:
-            authorization-uri: https://kauth.kakao.com/oauth/authorize
-            token-uri: https://kauth.kakao.com/oauth/token
-            user-info-uri: https://kapi.kakao.com/v2/user/me
-            user-info-authentication-method: header
-            user-name-attribute: id
-        registration:
-            kakao:
-                client-id: ${KAKAO_CLIENT_ID}
-                client-secret: ${KAKAO_CLIENT_SECRET}
-                redirect-uri: ${KAKAO_REDIRECT_URI}
-                client-name: kakao
-                client-authentication-method: client_secret_post
-                authorization-grant-type: authorization_code
-                scope:
-                  - account_email
-  sms:
-    api-key: ${SMS_API_KEY}
-    api-secret: ${SMS_API_SECRET}
-    provider: https://api.coolsms.co.kr
-    sender: ${SMS_SENDER}
-  datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:tcp://localhost/~/test # h2로 작업하실거면 본인 주소에 맞게 변경해서 사용해주세요!
-    username: sa
-  jpa:
-    hibernate:
-      ddl-auto: create
-
-springdoc:
-  default-consumes-media-type: application/json;charset=UTF-8
-  default-produces-media-type: application/json;charset=UTF-8
-  swagger-ui:
-    path: /swagger
-    disable-swagger-default-url: true
-    display-request-duration: true
-    operations-sorter: alpha
-  api-docs:
-    groups:
-      enabled: true
-spring:
-  security:
-    oauth2:
-      client:
-        provider:
-          kakao:
-            authorization-uri: https://kauth.kakao.com/oauth/authorize
-            token-uri: https://kauth.kakao.com/oauth/token
-            user-info-uri: https://kapi.kakao.com/v2/user/me
-            user-info-authentication-method: header
-            user-name-attribute: id
-        registration:
-            kakao:
-                client-id: ${KAKAO_CLIENT_ID}
-                client-secret: ${KAKAO_CLIENT_SECRET}
-                redirect-uri: ${KAKAO_REDIRECT_URI}
-                client-name: kakao
-                client-authentication-method: client_secret_post
-                authorization-grant-type: authorization_code
-                scope:
-                  - account_email
-  sms:
-    api-key: ${SMS_API_KEY}
-    api-secret: ${SMS_API_SECRET}
-    provider: https://api.coolsms.co.kr
-    sender: ${SMS_SENDER}
-  datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:tcp://localhost/~/test # h2로 작업하실거면 본인 주소에 맞게 변경해서 사용해주세요!
-    username: sa
-  jpa:
-    hibernate:
-      ddl-auto: create
-
-springdoc:
-  default-consumes-media-type: application/json;charset=UTF-8
-  default-produces-media-type: application/json;charset=UTF-8
-  swagger-ui:
-    path: /swagger
-    disable-swagger-default-url: true
-    display-request-duration: true
-    operations-sorter: alpha
-  api-docs:
-    groups:
-      enabled: true


### PR DESCRIPTION
### ✅ PR 종류
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### ⛏️ 반영 브랜치
- 
---
### 📑 변경 사항
- OAuthController 생성 -> RestController가 아닌 일반 Controller로 생성
    - api 서버 리다이렉트 때문에 -> 추후 RestController로 바꿔도 될 것 같음
- User Entity username 필드 length 수정 -> 임시로 지정한거라 수정 요망
- User Entity에 delete 시 필드들 null 값으로 변경하는 메서드 추가
    - 지역도 개인정보라 null로 변경해야 하는데 nullable이라 불가
    - 닉네임은 중복때문에 null로 변경해야 하는데 nullable이라 불가
- Auditing Entity deletedAt 찍는 메서드 추가
- Security Config permitAll Url에 oauth관련 url 추가
- CustomOAuth2SuccessHandler에 로그인 성공 후 토큰 발급, 프론트로 사용자 정보 JSON 형식으로 전송 로직 추가
    - 사용자의 토큰 존재 유무에 따라 로직 수정 필요
- CustomOAuth2UserService에 loadUser 메서드가 기존 CustomOAuth2User 반환하던 것을 UserDeatilsImpl을 반환하도록 수정
    - 카카오 탈퇴, 네이버 탈퇴 필요 로직 구현
    - saveOrUpdate 메서드에 기존 findByOauthId(email)로 되어있어 user을 찾지 못하던 것을 findByEmail(email)로 변경
- UserDetailsImpl이 OAuth2User도 implement하도록 수정 
---
### 📖 전달사항
- /oauth 관련 type들을 기존 requestBody로 받던 것에서 Query Parameter로 변경
  -> body에서 꺼내오는게 쓸데없이 번거로운 것 같아서... 프론트분들과 협의하고 다시 수정하겠습니다
- OAuthAttribute 생성하는 of000 메서드에 provider 필드 전부 소문자로 통일했습니다






