### PR TITLE
fix | 소셜 회원 가입 로직 수정

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/oauth/controller/OauthController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/oauth/controller/OauthController.java
@@ -1,14 +1,11 @@
 package dutchiepay.backend.domain.oauth.controller;
 
+import dutchiepay.backend.domain.user.service.UserService;
 import dutchiepay.backend.global.oauth.service.CustomOAuth2UserService;
 import dutchiepay.backend.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 public class OauthController {
 
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final UserService userService;
 
     @Operation(summary = "소셜 로그인(구현중)")
     @GetMapping("/signup")
@@ -30,11 +28,12 @@ public class OauthController {
     @DeleteMapping
     public String unlink(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam String type){
         if (type.equals("kakao")) {
-            customOAuth2UserService.deleteKakaoUser(userDetails);
+            userService.unlinkKakao(userDetails);
         } else {
-            customOAuth2UserService.deleteNaverUser(userDetails);
+            userService.unlinkNaver(userDetails);
         }
 
+        userService.deleteUser(userDetails);
         return "redirect:/";
     }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/exception/UserErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/exception/UserErrorCode.java
@@ -16,6 +16,7 @@ public enum UserErrorCode implements StatusCode {
     USER_NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다."),
     USER_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일입니다."),
     USER_INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다."),
+    DELETED_USER(HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/repository/UserRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/repository/UserRepository.java
@@ -12,7 +12,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     boolean existsByNickname(String nickname);
-    Optional<User> findByOauthId(String email);
+
+    Optional<User> findByOauthProviderAndEmail(String oauthId, String email);
 
     Optional<User> findByNickname(String username);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
@@ -5,10 +5,19 @@ import dutchiepay.backend.domain.user.exception.UserErrorCode;
 import dutchiepay.backend.domain.user.exception.UserErrorException;
 import dutchiepay.backend.domain.user.repository.UserRepository;
 import dutchiepay.backend.entity.User;
+import dutchiepay.backend.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -18,6 +27,13 @@ public class UserService {
     private final UserUtilService userUtilService;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final OAuth2AuthorizedClientService oauthService;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
+    private String naverClientId;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+    private String naverClientSecret;
 
     @Transactional
     public void signup(UserSignupRequestDto requestDto) {
@@ -68,5 +84,69 @@ public class UserService {
     public String changeUserPassword(UserChangePasswordRequestDto req) {
         // TODO 유저 비밀번호 재설정의 경우에는 토큰으로 유저를 파악해서 진행. 추후 구현 필요
         return null;
+    }
+
+    @Transactional
+    public void unlinkKakao(UserDetailsImpl userDetails) {
+        OAuth2AuthorizedClient authorizedClient = oauthService.loadAuthorizedClient(
+                "kakao", // OAuth2 로그인 제공자 이름 (예: "google", "naver")
+                userDetails.getUsername() // 현재 인증된 사용자
+        );
+        String kakaoAccess = null;
+        if (authorizedClient != null) {
+            kakaoAccess = authorizedClient.getAccessToken().getTokenValue();// Access Token 추출
+        }
+        RestTemplate restTemplate = new RestTemplate();
+
+        // POST 요청으로 데이터 전송
+        // HttpHeaders 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + kakaoAccess); // Authorization 헤더 설정
+
+        // HttpEntity에 본문 없이 헤더만 담기
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        // POST 요청 보내기 (request body 없음)
+        ResponseEntity<String> response = restTemplate.exchange(
+                "https://kapi.kakao.com/v1/user/unlink",  // 요청할 URL
+                HttpMethod.POST,                 // HTTP 메서드
+                entity,                          // HttpEntity (본문 없음, 헤더만 있음)
+                String.class                     // 응답 타입
+        );
+
+    }
+
+    @Transactional
+    public void unlinkNaver(UserDetailsImpl userDetails) {
+
+        OAuth2AuthorizedClient authorizedClient = oauthService.loadAuthorizedClient(
+                "naver", // OAuth2 로그인 제공자 이름 (예: "google", "naver")
+                userDetails.getUsername() // 현재 인증된 사용자
+        );
+
+        String naverAccess = null;
+        if (authorizedClient != null) {
+            naverAccess = authorizedClient.getAccessToken().getTokenValue();// Access Token 추출
+        }
+        RestTemplate restTemplate = new RestTemplate();
+
+        // POST 요청으로 데이터 전송
+        String data = "?client_id=" + naverClientId +
+                "&client_secret=" + naverClientSecret +
+                "&access_token=" + naverAccess +
+                "&service_provider=NAVER" +
+                "&grant_type=delete";
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                "https://nid.naver.com/oauth2.0/token" + data,  // 요청할 URL
+                HttpMethod.POST,                 // HTTP 메서드
+                null,                          // HttpEntity
+                String.class                     // 응답 타입
+        );
+    }
+
+    public void deleteUser(UserDetailsImpl userDetails) {
+        userRepository.findByEmail(userDetails.getEmail())
+                .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_EMAIL_NOT_FOUND)).delete();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/service/CustomOAuth2UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/service/CustomOAuth2UserService.java
@@ -3,46 +3,28 @@ package dutchiepay.backend.global.oauth.service;
 import dutchiepay.backend.domain.user.exception.UserErrorCode;
 import dutchiepay.backend.domain.user.exception.UserErrorException;
 import dutchiepay.backend.domain.user.repository.UserRepository;
+import dutchiepay.backend.domain.user.service.UserService;
 import dutchiepay.backend.entity.User;
-import dutchiepay.backend.global.oauth.dto.CustomOAuth2User;
 import dutchiepay.backend.global.oauth.dto.OAuthAttribute;
 import dutchiepay.backend.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
-import java.util.Collections;
+import java.util.Map;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
     private final UserRepository userRepository;
-    private final OAuth2AuthorizedClientService oauthService;
+    private final UserService userService;
 
-    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
-    private String naverClientId;
-
-    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
-    private String naverClientSecret;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -55,14 +37,23 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         OAuthAttribute oAuthAttribute = OAuthAttribute.of(userNameAttributeName, oAuth2User.getAttributes(), registrationId);
 
-        User user = saveOrUpdate(oAuthAttribute);
+        User user = saveOrUpdate(oAuthAttribute, oAuth2User.getAttributes());
 
         return new UserDetailsImpl(user, oAuth2User.getAttributes());
     }
 
-    private User saveOrUpdate(OAuthAttribute oAuthAttribute) {
-        User user = userRepository.findByEmail(oAuthAttribute.getEmail())
+    private User saveOrUpdate(OAuthAttribute oAuthAttribute, Map<String, Object> attributes) {
+        User user = userRepository.findByOauthProviderAndEmail(oAuthAttribute.getOauthProvider(), oAuthAttribute.getEmail())
                 .orElse(oAuthAttribute.toEntity());
+        if (user.getState() == 2) {
+            if (oAuthAttribute.getOauthProvider().equals("kakao")) {
+                userService.unlinkKakao(new UserDetailsImpl(user, attributes));
+            }
+            else {
+                userService.unlinkNaver(new UserDetailsImpl(user, attributes));
+            }
+            throw new UserErrorException(UserErrorCode.DELETED_USER);
+        }
 
         if (!user.getOauthProvider().equals(oAuthAttribute.getOauthProvider())) {
             User otherAccount = User.builder()
@@ -74,70 +65,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
             return userRepository.save(otherAccount);
         }
 
-        return user;
+        return userRepository.save(user);
     }
 
-    @Transactional
-    public void deleteKakaoUser(UserDetailsImpl userDetails) {
-        OAuth2AuthorizedClient authorizedClient = oauthService.loadAuthorizedClient(
-                "kakao", // OAuth2 로그인 제공자 이름 (예: "google", "naver")
-                userDetails.getUsername() // 현재 인증된 사용자
-        );
-        String kakaoAccess = null;
-        if (authorizedClient != null) {
-            kakaoAccess = authorizedClient.getAccessToken().getTokenValue();// Access Token 추출
-        }
-        RestTemplate restTemplate = new RestTemplate();
-
-        // POST 요청으로 데이터 전송
-        // HttpHeaders 생성
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "Bearer " + kakaoAccess); // Authorization 헤더 설정
-
-        // HttpEntity에 본문 없이 헤더만 담기
-        HttpEntity<Void> entity = new HttpEntity<>(headers);
-
-        // POST 요청 보내기 (request body 없음)
-        ResponseEntity<String> response = restTemplate.exchange(
-                "https://kapi.kakao.com/v1/user/unlink",  // 요청할 URL
-                HttpMethod.POST,                 // HTTP 메서드
-                entity,                          // HttpEntity (본문 없음, 헤더만 있음)
-                String.class                     // 응답 타입
-        );
-
-        userRepository.findByEmail(userDetails.getEmail())
-                .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_EMAIL_NOT_FOUND)).delete();
-    }
-
-    @Transactional
-    public void deleteNaverUser(UserDetailsImpl userDetails) {
-
-        OAuth2AuthorizedClient authorizedClient = oauthService.loadAuthorizedClient(
-                "naver", // OAuth2 로그인 제공자 이름 (예: "google", "naver")
-                userDetails.getUsername() // 현재 인증된 사용자
-        );
-
-        String naverAccess = null;
-        if (authorizedClient != null) {
-            naverAccess = authorizedClient.getAccessToken().getTokenValue();// Access Token 추출
-        }
-        RestTemplate restTemplate = new RestTemplate();
-
-        // POST 요청으로 데이터 전송
-        String data = "?client_id=" + naverClientId +
-                "&client_secret=" + naverClientSecret +
-                "&access_token=" + naverAccess +
-                "&service_provider=NAVER" +
-                "&grant_type=delete";
-
-        ResponseEntity<String> response = restTemplate.exchange(
-                "https://nid.naver.com/oauth2.0/token" + data,  // 요청할 URL
-                HttpMethod.POST,                 // HTTP 메서드
-                null,                          // HttpEntity
-                String.class                     // 응답 타입
-        );
-
-        userRepository.findByEmail(userDetails.getEmail())
-                .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_EMAIL_NOT_FOUND)).delete();
-    }
 }


### PR DESCRIPTION
### ✅ PR 종류
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### ⛏️ 반영 브랜치
-
---
### 📑 변경 사항
- 소셜 로그인 시 saveOrUpdate 메서드에서 state == 2인 회원은 UserErrorException -> DELETED_USER 발생
- 회원 정보를 받아온 후에는 이미 연동이 된 상태기 때문에 exception이 발생하더라도 unlink 메서드 호출
- 기존 CustomOAuth2UserService에 있던 deleteKakaoUser, deleteNaverUser 메서드를 @Transactional 문제로 인하여 UserService 클래스로 이관
- 탈퇴한 회원의 정보를 삭제하는 user.delete를 public 메서드로 분리
    - 후에 일반 회원 탈퇴 시에도 필요할 것 같아 그냥 분리하였습니다.
- saveOrUpdate 메서드에서 유저 정보를 단순히 email로만 찾던 것을 OauthProvider와 Email로 찾는 것으로 수정
    - 탈퇴 시 oauthId도 null로 만들기 때문에 남아있는 정보 중 provider 와 email을 활용하여 이메일 중복 문제와 타 소셜 계정 문제를 해결하였습니다.
---
📖 참고 사항
- 노트북 배터리 이슈로 급히 작성하느라 코드가 좀 더럽습니다,,, 추후 수정하도록 하겠습니다







