### PR TITLE
Profile Request DTO 생성 / JWT 검증 필터 무한 진입 문제 해결 / LoggingAspect 수정

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/controller/ProfileController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/controller/ProfileController.java
@@ -1,15 +1,11 @@
 package dutchiepay.backend.domain.profile.controller;
 
-import dutchiepay.backend.domain.profile.dto.ChangeAddressRequestDto;
-import dutchiepay.backend.domain.profile.dto.CreateAskRequestDto;
-import dutchiepay.backend.domain.profile.dto.CreateReviewRequestDto;
+import dutchiepay.backend.domain.profile.dto.*;
 import dutchiepay.backend.domain.profile.service.ProfileService;
 import dutchiepay.backend.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -101,28 +97,32 @@ public class ProfileController {
      */
     @Operation(summary = "닉네임 변경 (구현 완료)")
     @PatchMapping("/nickname")
-    public ResponseEntity<?> changeNickname(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody String nickname) {
-        profileService.changeNickname(userDetails.getUser(), nickname);
+    public ResponseEntity<?> changeNickname(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                            @Valid @RequestBody ChangeNicknameRequestDto request) {
+        profileService.changeNickname(userDetails.getUser(), request.getNickname());
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "프로필 이미지 변경 (구현 완료)")
     @PatchMapping("/image")
-    public ResponseEntity<?> changeProfileImage(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody String profileImg) {
-        profileService.changeProfileImage(userDetails.getUser(), profileImg);
+    public ResponseEntity<?> changeProfileImage(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                @Valid @RequestBody ChangeProfileImgRequestDto request) {
+        profileService.changeProfileImage(userDetails.getUser(), request.getProfileImg());
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "지역 변경 (구현 완료)")
     @PatchMapping("/location")
-    public ResponseEntity<?> changeLocation(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody String location) {
-        profileService.changeLocation(userDetails.getUser(), location);
+    public ResponseEntity<?> changeLocation(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                            @Valid @RequestBody ChangeLocationRequestDto request) {
+        profileService.changeLocation(userDetails.getUser(), request.getLocation());
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "배송지 정보 변경 (구현 완료)")
     @PatchMapping("/address")
-    public ResponseEntity<?> changeAddress(@AuthenticationPrincipal UserDetailsImpl userDetails, @Valid @RequestBody ChangeAddressRequestDto req) {
+    public ResponseEntity<?> changeAddress(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                           @Valid @RequestBody ChangeAddressRequestDto req) {
         profileService.changeAddress(userDetails.getUser(), req);
         return ResponseEntity.ok().build();
     }
@@ -130,10 +130,8 @@ public class ProfileController {
     @Operation(summary = "전화번호 변경 (구현 완료)")
     @PatchMapping("/phone")
     public ResponseEntity<?> changePhone(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                         @NotBlank
-                                         @Pattern(regexp = "^\\d{11}$", message = "전화번호는 11자리 숫자여야 합니다.")
-                                         @RequestBody String phone) {
-        profileService.changePhone(userDetails.getUser(), phone);
+                                         @Valid @RequestBody ChangePhoneRequestDto request ) {
+        profileService.changePhone(userDetails.getUser(), request.getPhone());
         return ResponseEntity.ok().build();
     }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/ChangeLocationRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/ChangeLocationRequestDto.java
@@ -1,0 +1,11 @@
+package dutchiepay.backend.domain.profile.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChangeLocationRequestDto {
+    private String location;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/ChangeNicknameRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/ChangeNicknameRequestDto.java
@@ -1,0 +1,16 @@
+package dutchiepay.backend.domain.profile.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChangeNicknameRequestDto {
+
+    @NotBlank
+    @Pattern(regexp = "^.{1,8}$", message = "닉네임은 8글자까지 가능합니다.")
+    private String nickname;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/ChangePhoneRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/ChangePhoneRequestDto.java
@@ -1,0 +1,16 @@
+package dutchiepay.backend.domain.profile.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChangePhoneRequestDto {
+
+    @NotBlank
+    @Pattern(regexp = "^\\d{11}$", message = "전화번호는 11자리 숫자여야 합니다.")
+    private String phone;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/ChangeProfileImgRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/ChangeProfileImgRequestDto.java
@@ -1,0 +1,11 @@
+package dutchiepay.backend.domain.profile.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChangeProfileImgRequestDto {
+    private String profileImg;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/exception/ProfileErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/exception/ProfileErrorCode.java
@@ -1,6 +1,6 @@
 package dutchiepay.backend.domain.profile.exception;
 
-import dutchiepay.backend.global.Exception.StatusCode;
+import dutchiepay.backend.global.exception.StatusCode;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/exception/UserErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/exception/UserErrorCode.java
@@ -1,6 +1,6 @@
 package dutchiepay.backend.domain.user.exception;
 
-import dutchiepay.backend.global.Exception.StatusCode;
+import dutchiepay.backend.global.exception.StatusCode;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/config/SecurityConfig.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/config/SecurityConfig.java
@@ -3,10 +3,7 @@ package dutchiepay.backend.global.config;
 import dutchiepay.backend.domain.user.repository.UserRepository;
 import dutchiepay.backend.global.jwt.JwtUtil;
 import dutchiepay.backend.global.oauth.handler.CustomOAuth2SuccessHandler;
-import dutchiepay.backend.global.security.JwtAuthenticationFilter;
-import dutchiepay.backend.global.security.JwtVerificationFilter;
-import dutchiepay.backend.global.security.NicknameQueryParamFilter;
-import dutchiepay.backend.global.security.UserDetailsServiceImpl;
+import dutchiepay.backend.global.security.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -22,6 +19,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -84,6 +82,11 @@ public class SecurityConfig {
     }
 
     @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return new JwtAuthenticationEntryPoint();
+    }
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
@@ -104,7 +107,10 @@ public class SecurityConfig {
                 UsernamePasswordAuthenticationFilter.class)
             .addFilterBefore(jwtVerificationFilter(), JwtAuthenticationFilter.class)
             .addFilterBefore(new JwtAuthenticationFilter(jwtUtil, userRepository, passwordEncoder()),
-                UsernamePasswordAuthenticationFilter.class);
+                UsernamePasswordAuthenticationFilter.class)
+            .exceptionHandling(exception ->
+                    exception
+                            .authenticationEntryPoint(authenticationEntryPoint()));
 
         return http.build();
     }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/exception/CustomExceptionHandler.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/exception/CustomExceptionHandler.java
@@ -4,10 +4,17 @@ import dutchiepay.backend.domain.profile.exception.ProfileErrorException;
 import dutchiepay.backend.domain.user.exception.UserErrorException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+/**
+ * @author     dnjsals45
+ * @version    1.0.0
+ * @since      1.0.0
+ * @return     ResponseEntity<?>
+ */
 @Slf4j(topic = "CustomExceptionHandler")
 @RestControllerAdvice
 public class CustomExceptionHandler {
@@ -24,5 +31,32 @@ public class CustomExceptionHandler {
         log.warn("handleProcessorException : {}", e.getMessage());
         final ErrorMessage message = ErrorMessage.of(e.getMessage());
         return ResponseEntity.status(e.getProfileErrorCode().getHttpStatus()).body(message);
+    }
+
+    /**
+     * Validation 에러 처리가 된 경우
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.warn("handleMethodArgumentNotValidException : {}", e.getMessage());
+        final ErrorMessage message = ErrorMessage.of(e.getMessage());
+        return ResponseEntity.badRequest().body(message);
+    }
+
+    /**
+     * NullPointerException 에러 처리가 된 경우
+     */
+    @ExceptionHandler(NullPointerException.class)
+    protected ResponseEntity<?> handleNullPointerException(NullPointerException e) {
+        log.warn("handleNullPointerException : {}", e.getMessage());
+        final ErrorMessage message = ErrorMessage.of(e.getMessage());
+        return ResponseEntity.badRequest().body(message);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    protected ResponseEntity<?> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.warn("handleHttpMessageNotReadableException : {}", e.getMessage());
+        final ErrorMessage message = ErrorMessage.of(e.getMessage());
+        return ResponseEntity.badRequest().body(message);
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/exception/CustomExceptionHandler.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/exception/CustomExceptionHandler.java
@@ -1,13 +1,14 @@
-package dutchiepay.backend.global.Exception;
+package dutchiepay.backend.global.exception;
 
 import dutchiepay.backend.domain.profile.exception.ProfileErrorException;
 import dutchiepay.backend.domain.user.exception.UserErrorException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@Slf4j
+@Slf4j(topic = "CustomExceptionHandler")
 @RestControllerAdvice
 public class CustomExceptionHandler {
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/exception/ErrorMessage.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/exception/ErrorMessage.java
@@ -1,4 +1,4 @@
-package dutchiepay.backend.global.Exception;
+package dutchiepay.backend.global.exception;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/exception/StatusCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/exception/StatusCode.java
@@ -1,4 +1,4 @@
-package dutchiepay.backend.global.Exception;
+package dutchiepay.backend.global.exception;
 
 import org.springframework.http.HttpStatus;
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/logging/LoggingAspect.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/logging/LoggingAspect.java
@@ -1,86 +1,87 @@
-//package dutchiepay.backend.global.logging;
-//
-//import jakarta.servlet.http.Cookie;
-//import jakarta.servlet.http.HttpServletRequest;
-//import lombok.extern.slf4j.Slf4j;
-//import org.aspectj.lang.JoinPoint;
-//import org.aspectj.lang.annotation.*;
-//import org.aspectj.lang.reflect.MethodSignature;
-//import org.springframework.http.HttpHeaders;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.stereotype.Component;
-//import org.springframework.web.context.request.RequestContextHolder;
-//import org.springframework.web.context.request.ServletRequestAttributes;
-//
-//import java.lang.reflect.Method;
-//import java.util.Map;
-//
-//@Slf4j
-//@Component
-//@Aspect
-//public class LoggingAspect {
-//    @Pointcut(value = "execution(* dutchiepay.backend.domain.*.controller.*Controller.*(..))")
-//    private void logCut() {
-//    }
-//
-//    @Before("logCut()")
-//    public void beforeLogging(JoinPoint joinPoint) {
-//        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
-//        Method method = methodSignature.getMethod();
-//
-//        log.info("================================= Request ==================================");
-//        log.info("요청 메서드 이름 : {}", method.getName());
-//        log.debug("요청 메서드 경로 : {}", method.getDeclaringClass() + "." + method.getName());
-//
-//        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
-//        Cookie[] cookies = request.getCookies();
-//
-//        if (cookies != null) {
-//            for (Cookie cookie : cookies) {
-//                if (cookie.getName().equals("Refresh-Token")) { // 프론트에서 어떻게 보내줄지 모르니 나중에 수정
-//                    log.debug("요청 쿠키 값 : {}", cookie.getName() + "=" + cookie.getValue());
-//                }
-//            }
-//        }
-//
-//        Object[] args = joinPoint.getArgs();
-//
-//        if (args.length == 0) {
-//            log.info("인자가 없는 요청");
-//        }
-//
-//        for (Object arg : args) {
-//            if (arg == null) continue;
-//
-//            log.info("요청 파라미터 타입 : {} ⇾ 값 : {}", arg.getClass().getSimpleName(), arg);
-//        }
-//    }
-//
-//    @AfterReturning(pointcut = "logCut()", returning = "result")
-//    public void afterLogging(JoinPoint joinPoint, Object result) {
-//        ResponseEntity<?> response = (ResponseEntity<?>) result;
-//        HttpHeaders headers = response.getHeaders();
-//
-//        log.info("================================= Response =================================");
-//        log.info("응답 코드 : {}", response.getStatusCode());
-//        log.info("응답 헤더 : {}", headers);
-//
-//        for (Map.Entry<String, String> entry : headers.toSingleValueMap().entrySet()) {
-//            if (entry.getKey().equals(HttpHeaders.SET_COOKIE) || entry.getKey().equals(HttpHeaders.AUTHORIZATION)) {
-//                log.debug("응답 헤더 : {} ⇾ 값 : {}", entry.getKey(), entry.getValue());
-//            } else {
-//                log.info("응답 헤더 : {} ⇾ 값 : {}", entry.getKey(), entry.getValue());
-//            }
-//        }
-//
-//        log.info("응답 내용 : {}", response.getBody());
-//        log.info("============================================================================");
-//    }
-//
-//    @AfterThrowing(pointcut = "logCut()", throwing = "exception")
-//    public void afterThrowingLogging(JoinPoint joinPoint, Exception exception) {
-//        log.error("================================= Exception =================================");
-//        log.error("예외 종류 : {} ⇾ 메시지 : {}", exception.getClass().getSimpleName(), exception.getMessage());
-//        log.error("=============================================================================");
-//    }
-//}
+package dutchiepay.backend.global.logging;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.*;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+@Slf4j
+@Component
+@Aspect
+public class LoggingAspect {
+    @Pointcut(value = "execution(* dutchiepay.backend.domain.*.controller.*Controller.*(..)) " +
+            "&& !execution(* dutchiepay.backend.domain.oauth.controller.*Controller.*(..))")
+    private void logCut() {
+    }
+
+    @Before("logCut()")
+    public void beforeLogging(JoinPoint joinPoint) {
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        Method method = methodSignature.getMethod();
+
+        log.info("================================= Request ==================================");
+        log.info("요청 메서드 이름 : {}", method.getName());
+        log.debug("요청 메서드 경로 : {}", method.getDeclaringClass() + "." + method.getName());
+
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("Refresh-Token")) { // 프론트에서 어떻게 보내줄지 모르니 나중에 수정
+                    log.debug("요청 쿠키 값 : {}", cookie.getName() + "=" + cookie.getValue());
+                }
+            }
+        }
+
+        Object[] args = joinPoint.getArgs();
+
+        if (args.length == 0) {
+            log.info("인자가 없는 요청");
+        }
+
+        for (Object arg : args) {
+            if (arg == null) continue;
+
+            log.info("요청 파라미터 타입 : {} ⇾ 값 : {}", arg.getClass().getSimpleName(), arg);
+        }
+    }
+
+    @AfterReturning(pointcut = "logCut()", returning = "result")
+    public void afterLogging(JoinPoint joinPoint, Object result) {
+        ResponseEntity<?> response = (ResponseEntity<?>) result;
+        HttpHeaders headers = response.getHeaders();
+
+        log.info("================================= Response =================================");
+        log.info("응답 코드 : {}", response.getStatusCode());
+        log.info("응답 헤더 : {}", headers);
+
+        for (Map.Entry<String, String> entry : headers.toSingleValueMap().entrySet()) {
+            if (entry.getKey().equals(HttpHeaders.SET_COOKIE) || entry.getKey().equals(HttpHeaders.AUTHORIZATION)) {
+                log.debug("응답 헤더 : {} ⇾ 값 : {}", entry.getKey(), entry.getValue());
+            } else {
+                log.info("응답 헤더 : {} ⇾ 값 : {}", entry.getKey(), entry.getValue());
+            }
+        }
+
+        log.info("응답 내용 : {}", response.getBody());
+        log.info("============================================================================");
+    }
+
+    @AfterThrowing(pointcut = "logCut()", throwing = "exception")
+    public void afterThrowingLogging(JoinPoint joinPoint, Exception exception) {
+        log.error("================================= Exception =================================");
+        log.error("예외 종류 : {} ⇾ 메시지 : {}", exception.getClass().getSimpleName(), exception.getMessage());
+        log.error("=============================================================================");
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/security/JwtAuthenticationEntryPoint.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,19 @@
+package dutchiepay.backend.global.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/security/JwtVerificationFilter.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/security/JwtVerificationFilter.java
@@ -33,6 +33,9 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
+        log.warn("url: {}", request.getRequestURI());
+        log.warn("method: {}", request.getMethod());
+
         String token = jwtUtil.getJwtFromHeader(request);
 
         if (token != null) {

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/security/JwtVerificationFilter.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/security/JwtVerificationFilter.java
@@ -33,9 +33,6 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        log.warn("url: {}", request.getRequestURI());
-        log.warn("method: {}", request.getMethod());
-
         String token = jwtUtil.getJwtFromHeader(request);
 
         if (token != null) {

--- a/DutchiePay/src/test/java/dutchiepay/backend/UsersCouponRepositoryPerformanceTest.java
+++ b/DutchiePay/src/test/java/dutchiepay/backend/UsersCouponRepositoryPerformanceTest.java
@@ -112,6 +112,7 @@ class UsersCouponRepositoryPerformanceTest {
     }
 
     @Test
+    @Disabled
     void 성능테스트_유저1_쿠폰100() {
         prepare(1, 100);
         User testUser1 = users.get(0);
@@ -136,6 +137,7 @@ class UsersCouponRepositoryPerformanceTest {
     }
 
     @Test
+    @Disabled
     void 성능테스트_유저1_쿠폰1000() {
         prepare(1, 1000);
         User testUser1 = users.get(0);


### PR DESCRIPTION
### ✅ PR 종류
- [x] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### ⛏️ 반영 브랜치
- fix/profile -> main
---
### 📑 변경 사항
---
- ### 기존 유저 변경 로직에서 @RequestBody에서 String으로 받던 부분을 Json 형식으로 받을 수 있도록 모두 Dto 클래스 생성

- ### GlobalExceptionHandler 에서 Exception을 추가

- ### LoggingAspect 오류 해결
> 기존에 Oauth 컨트롤러의 경우 ResponseEntity<?>이 아닌 String 형태로 redirect를 시키기 때문에 타입 캐스팅이 되지 않던 문제 발생
> 이를 해결하기 위해 @Pointcut value값 수정해서 Oauth 컨트롤러만 동작하지 않도록 했습니다.

- ### JWT 검증 필터 무한 진입 문제
> <img width="805" alt="스크린샷 2024-09-20 오후 5 30 01" src="https://github.com/user-attachments/assets/5797ffd9-95f9-420d-a2c8-b2da00f41e83">
> Swagger 에서 인증이 필요한 엔드포인트에 JSON이 파싱되지 않도록 작성하면 위와 같이 올바른 상태코드가 아니라 연결이 되지 않았다는 알 수 없는 오류가 발생
> <img width="806" alt="스크린샷 2024-09-20 오후 5 30 50" src="https://github.com/user-attachments/assets/e79ed786-81de-49eb-8747-83c3d81d8821">
> 오류 발생 이후에는 JWT 필터로 무한 반복하는 것을 확인할 수 있었음

> ### 문제 원인
> 1. 인증이 필요한 요청이 들어와 JWT 검증 필터를 거침
> 2. 컨트롤러로 진입하는 과정에서 Request의 Json이 파싱되지 않아 HttpMessageNotReadableException 오류 발생 
> 3. 스프링 시큐리티에서 인증되지 않은 요청으로 파악해 인증 실패로 처리하고 /login으로 리다이렉션 시킴
(securityFilterChain에서 .formLogin(AbstractHttpConfigurer::disable) 옵션이 존재하지만, 내부적으로 처리되는 것으로 생각)
> 4. /login url을 통해 JWT 검증 필터로 다시 들어옴
> 5. .anyRequest.authenticated() 로 인해 /login 또한 인증이 되어야 하는데 인증 실패로 처리
> 6. 다시 /login으로 리다이렉션
> 7. 무한 반복..

의 과정에 의해서 오류가 발생한 것으로 파악하고 있습니다. 첫 /login 요청 이후에도 계속해서 리다이렉션 시키는 것이 맞는지는 정확하게 파악하지 못했습니다.

> ### 수정 사항
> securityFilterChain 내부에 .exceptionHandling.authenticationEntryPoint 및 exception 클래스 추가(401에러 반환)
> 실제로는 인증되지 않은 것이 아닌 Json 파싱 문제이기 때문에 GlobalException 추가










