### PR TITLE
fix | 일반 로그인 response 수정, 소셜 회원가입 성공 로직 수정

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/oauth/controller/OauthController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/oauth/controller/OauthController.java
@@ -1,10 +1,13 @@
 package dutchiepay.backend.domain.oauth.controller;
 
+import dutchiepay.backend.domain.user.dto.UserLoginResponseDto;
 import dutchiepay.backend.domain.user.service.UserService;
 import dutchiepay.backend.global.oauth.service.CustomOAuth2UserService;
 import dutchiepay.backend.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -22,6 +25,12 @@ public class OauthController {
     public String signup(@RequestParam String type) {
 
         return "redirect:/oauth2/authorization/" + type;
+    }
+
+    @Operation(summary = "소셜 로그인 완료 후 회원 정보 요청받을 controller")
+    @PostMapping("/users")
+    public ResponseEntity<UserLoginResponseDto> userInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok(userService.userInfo(userDetails));
     }
 
     @Operation(summary = "소셜 회원 탈퇴(구현중)")

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/repository/UserRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/repository/UserRepository.java
@@ -16,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByOauthProviderAndEmail(String oauthId, String email);
 
     Optional<User> findByNickname(String username);
+
+    Optional<User> findByEmailAndOauthProviderIsNull(String email);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import dutchiepay.backend.domain.user.exception.UserErrorCode;
 import dutchiepay.backend.domain.user.exception.UserErrorException;
 import dutchiepay.backend.domain.user.repository.UserRepository;
 import dutchiepay.backend.entity.User;
+import dutchiepay.backend.global.jwt.JwtUtil;
 import dutchiepay.backend.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -147,5 +148,14 @@ public class UserService {
     public void deleteUser(UserDetailsImpl userDetails) {
         userRepository.findByEmail(userDetails.getEmail())
                 .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_EMAIL_NOT_FOUND)).delete();
+    }
+
+    public UserLoginResponseDto userInfo(UserDetailsImpl userDetails) {
+        User user = userRepository.findByOauthProviderAndEmail(userDetails.getOAuthProvider(), userDetails.getEmail())
+                .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_NOT_FOUND));
+        final JwtUtil jwtUtil = new JwtUtil();
+        String accessToken = jwtUtil.createAccessToken(user.getUserId());
+
+        return UserLoginResponseDto.toDto(user, accessToken);
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/handler/CustomOAuth2SuccessHandler.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/handler/CustomOAuth2SuccessHandler.java
@@ -50,7 +50,8 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
         user.createRefreshToken(refreshToken);
         userRepository.save(user);
 
-        sendResponse(response, UserLoginResponseDto.toDto(user, accessToken));
+        response.sendRedirect("/oauth/users?access=" + accessToken);
+
     }
 
     private void sendResponse(HttpServletResponse response, UserLoginResponseDto userLoginResponseDto) throws IOException {

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/security/UserDetailsImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/security/UserDetailsImpl.java
@@ -79,4 +79,8 @@ public class UserDetailsImpl implements OAuth2User, UserDetails {
         return user.getUserId().toString();
     }
 
+    public String getOAuthProvider() {
+        return user.getOauthProvider();
+    }
+
 }


### PR DESCRIPTION
### ✅ PR 종류
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 이메일 로그인 성공 시 response 값 수정
    - 기존 로그인 시 findByEmail로만 찾아 중복 이메일로 인한 에러가 발생 
       -> findByEmailAndOAuthProviderIsNull로 변경하여 이메일 유저 중에서만 찾게 수정
- 소셜 회원가입 시 CORS 에러 문제
   -> 소셜 로그인 성공 후 빈 페이지로 accessToken과 함께 리다이렉트 후 POST로 회원 정보 요청하는 방법으로 수정
---
### 📖 참고 사항
- 지금 보니 뭔가 코드가 이상한데,,, 추후 수정하겠습니다
    - UserService -> userInfo 메서드에서 user 찾는 부분