### PR TITLE
기존 로직 exception 추가 및 S3 이미지 파일 이름 구성 방식 변경

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/BuyCategory.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/BuyCategory.java
@@ -38,4 +38,13 @@ public enum BuyCategory {
                 .findAny()
                 .orElseThrow(() -> new IllegalArgumentException(String.format("일치하는 카테고리명이 없습니다 %s", categoryName)));
     }
+
+    public static boolean isExist(String categoryName) {
+        for (BuyCategory buyCategory : BuyCategory.values()) {
+            if (buyCategory.getCategory().equals(categoryName)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/image/service/ImageService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/image/service/ImageService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 
 import java.net.URL;
 import java.util.Date;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -33,9 +32,7 @@ public class ImageService {
      * @return     GetPreSignedUrlResponseDto(presigned url)
      */
     public GetPreSignedUrlResponseDto getPreSignedUrl(String fileName) {
-        String uniqueFileName = UUID.randomUUID() + "_" + fileName;
-
-        GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePresignedUrlRequest(bucket, uniqueFileName);
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePresignedUrlRequest(bucket, fileName);
         URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
 
         return GetPreSignedUrlResponseDto.builder()

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
@@ -1,5 +1,6 @@
 package dutchiepay.backend.domain.profile.service;
 
+import dutchiepay.backend.domain.commerce.BuyCategory;
 import dutchiepay.backend.domain.coupon.repository.UsersCouponRepository;
 import dutchiepay.backend.domain.order.repository.*;
 import dutchiepay.backend.domain.profile.dto.*;
@@ -50,6 +51,10 @@ public class ProfileService {
 
 
     public List<GetMyLikesResponseDto> getMyLike(User user, String category) {
+        if (!BuyCategory.isExist(category)) {
+            throw new ProfileErrorException(ProfileErrorCode.INVALID_CATEGORY);
+        }
+
         return profileRepository.getMyLike(user, category);
     }
 
@@ -74,7 +79,7 @@ public class ProfileService {
     }
 
     @Transactional
-    public void createReview(User user, @Valid CreateReviewRequestDto req) {
+    public void createReview(User user, CreateReviewRequestDto req) {
         Orders order = ordersRepository.findById(req.getOrderId()).orElseThrow(() -> new IllegalArgumentException("주문 정보가 없습니다."));
 
         if (user != order.getUser()) {
@@ -92,7 +97,7 @@ public class ProfileService {
     }
 
     @Transactional
-    public void createAsk(User user, @Valid CreateAskRequestDto req) {
+    public void createAsk(User user, CreateAskRequestDto req) {
         Orders order = ordersRepository.findById(req.getOrderId()).orElseThrow(() -> new IllegalArgumentException("주문 정보가 없습니다."));
 
         if (user != order.getUser()) {

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/exception/UserErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/exception/UserErrorCode.java
@@ -17,6 +17,7 @@ public enum UserErrorCode implements StatusCode {
     USER_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일입니다."),
     USER_INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다."),
     DELETED_USER(HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다."),
+    USER_SAME_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 동일합니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
@@ -75,6 +75,10 @@ public class UserService {
     public void changeNonUserPassword(NonUserChangePasswordRequestDto req) {
         User user = userUtilService.commonUserFindByEmail(req.getEmail());
 
+        if (passwordEncoder.matches(req.getPassword(), user.getPassword())) {
+            throw new UserErrorException(UserErrorCode.USER_SAME_PASSWORD);
+        }
+
         user.changePassword(passwordEncoder.encode(req.getPassword()));
         userRepository.save(user);
     }
@@ -82,6 +86,10 @@ public class UserService {
     @Transactional
     public void changeUserPassword(User user, UserChangePasswordRequestDto req) {
         user.changePassword(passwordEncoder.encode(req.getPassword()));
+
+        if (passwordEncoder.matches(req.getPassword(), user.getPassword())) {
+            throw new UserErrorException(UserErrorCode.USER_SAME_PASSWORD);
+        }
 
         userRepository.save(user);
     }


### PR DESCRIPTION
### ✅ PR 종류
- [] 기능 추가
- [] 버그 수정
- [] 리팩토링
- [] 테스트
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 예외처리 될 수 있는 경우 2가지를 추가했습니다(이전 비밀번호와 현재 비밀번호가 같을 경우, 존재하지 않는 카테고리가 들어올 경우)
- s3에 저장되는 이미지 이름을 프론트에서 보내주는 형태 그대로 사용하는 것으로 변경했습니다.(프론트에서 참조를 할 수 있도록)
---
### 📖 참고 사항








