### PR TITLE
Feat | 재로그인, 액세스 토큰 재발급 기능 구현

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/controller/UserController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/controller/UserController.java
@@ -5,6 +5,8 @@ import dutchiepay.backend.domain.user.dto.FindPasswordRequestDto;
 import dutchiepay.backend.domain.user.dto.NonUserChangePasswordRequestDto;
 import dutchiepay.backend.domain.user.dto.PhoneAuthRequestDto;
 import dutchiepay.backend.domain.user.dto.UserChangePasswordRequestDto;
+import dutchiepay.backend.domain.user.dto.UserReLoginRequestDto;
+import dutchiepay.backend.domain.user.dto.UserReissueRequestDto;
 import dutchiepay.backend.domain.user.dto.UserSignupRequestDto;
 import dutchiepay.backend.domain.user.service.UserService;
 import dutchiepay.backend.global.jwt.JwtUtil;
@@ -96,5 +98,17 @@ public class UserController {
 
         userService.deleteUser(userDetails);
         return ResponseEntity.ok().body(null);
+    }
+
+    @Operation(summary = "자동로그인(구현 완료)")
+    @PostMapping("/relogin")
+    public ResponseEntity<?> reLogin(@Valid @RequestBody UserReLoginRequestDto requestDto) {
+        return ResponseEntity.ok().body(userService.reLogin(requestDto.getRefresh()));
+    }
+
+    @Operation(summary = "access Token 재발급")
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(@Valid @RequestBody UserReissueRequestDto requestDto) {
+        return ResponseEntity.ok().body(userService.reissue(requestDto));
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserLoginRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserLoginRequestDto.java
@@ -1,6 +1,7 @@
 package dutchiepay.backend.domain.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,8 +9,8 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserLoginRequestDto {
 
     @NotBlank

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserLoginResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserLoginResponseDto.java
@@ -2,11 +2,16 @@ package dutchiepay.backend.domain.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dutchiepay.backend.entity.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserLoginResponseDto {
 
     private Long userId;
@@ -21,13 +26,13 @@ public class UserLoginResponseDto {
 
     public static UserLoginResponseDto toDto(User user, String access) {
         return UserLoginResponseDto.builder()
-                .userId(user.getUserId())
-                .type(user.getOauthProvider())
-                .nickname(user.getNickname())
-                .profileImg(user.getProfileImg())
-                .location(user.getLocation())
-                .access(access)
-                .refresh(user.getRefreshToken())
-                .certified(user.getPhone() != null).build();
+            .userId(user.getUserId())
+            .type(user.getOauthProvider())
+            .nickname(user.getNickname())
+            .profileImg(user.getProfileImg())
+            .location(user.getLocation())
+            .access(access)
+            .refresh(user.getRefreshToken())
+            .certified(user.getPhone() != null).build();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserReLoginRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserReLoginRequestDto.java
@@ -1,0 +1,18 @@
+package dutchiepay.backend.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserReLoginRequestDto {
+
+    @NotBlank
+    private String refresh;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserReLoginResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserReLoginResponseDto.java
@@ -1,0 +1,36 @@
+package dutchiepay.backend.domain.user.dto;
+
+import dutchiepay.backend.entity.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserReLoginResponseDto {
+
+    Long userId;
+    String type;
+    String nickname;
+    String profileImg;
+    String location;
+    String access;
+    Boolean isCertified;
+
+    public static UserReLoginResponseDto toDto(final User user, String access,
+        Boolean isCertified) {
+        return UserReLoginResponseDto.builder()
+            .userId(user.getUserId())
+            .type(user.getOauthProvider())
+            .nickname(user.getNickname())
+            .profileImg(user.getProfileImg())
+            .location(user.getLocation())
+            .access(access)
+            .isCertified(isCertified)
+            .build();
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserReissueRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserReissueRequestDto.java
@@ -1,0 +1,21 @@
+package dutchiepay.backend.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserReissueRequestDto {
+
+    @NotBlank
+    private String access;
+
+    @NotBlank
+    private String refresh;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserReissueResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserReissueResponseDto.java
@@ -1,0 +1,22 @@
+package dutchiepay.backend.domain.user.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserReissueResponseDto {
+
+    String access;
+
+    public static UserReissueResponseDto toDto(String access) {
+        return UserReissueResponseDto.builder()
+            .access(access)
+            .build();
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserSignupRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserSignupRequestDto.java
@@ -3,11 +3,16 @@ package dutchiepay.backend.domain.user.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserSignupRequestDto {
 
     @NotBlank(message = "이메일을 입력해주세요.")

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/repository/UserRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/repository/UserRepository.java
@@ -4,9 +4,8 @@ import dutchiepay.backend.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface UserRepository extends JpaRepository<User, Long> {
+
     Optional<User> findByPhone(String phone);
 
     Optional<User> findByEmail(String email);
@@ -22,4 +21,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByPhoneAndOauthProviderIsNull(String phone);
 
     Optional<User> findByEmailAndPhoneAndOauthProviderIsNull(String email, String phone);
+
+    Optional<User> findByRefreshToken(String refreshToken);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/AccessTokenBlackListService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/AccessTokenBlackListService.java
@@ -2,18 +2,15 @@ package dutchiepay.backend.domain.user.service;
 
 import dutchiepay.backend.domain.user.repository.AccessTokenBlackListRepository;
 import dutchiepay.backend.entity.AccessTokenBlackList;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@RequiredArgsConstructor
 @Service
 public class AccessTokenBlackListService {
 
     private final AccessTokenBlackListRepository accessTokenBlackListRepository;
-
-    public AccessTokenBlackListService(
-        AccessTokenBlackListRepository accessTokenBlackListRepository) {
-        this.accessTokenBlackListRepository = accessTokenBlackListRepository;
-    }
 
     @Transactional
     public void addBlackList(String token) {


### PR DESCRIPTION
### ✅ PR 종류
- [x] 기능 추가
- [] 버그 수정
- [x] 리팩토링
- [] 테스트
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 재로그인 및 액세스 토큰 재발급 기능 구현
- 어노테이션 통일성 있게 수정
---
### 📖 참고 사항
- 재로그인, 액세스 토큰 재발급 시 헤더가 아닌 바디로 들어오고 헤더가 비어있습니다
- 따라서 시큐리티 필터를 거치더라도 jwtVerificationFilter에서 작동하지 않기 때문에 컨트롤러에서 작성하였습니다
- 방법이 맞지 않다면 수정하겠습니다!







