### PR TITLE
Fix | 회원가입 시 이메일 및 번호 체크 변경

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/controller/UserController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/controller/UserController.java
@@ -58,6 +58,20 @@ public class UserController {
         return ResponseEntity.ok().body(null);
     }
 
+    @Operation(summary = "이메일 검사 중복확인(구현 완료)", description = "소셜 가입 이메일 제외, 이메일 회원가입만 중복 체크")
+    @GetMapping
+    public ResponseEntity<?> isExistEmail(@RequestParam(required = false) String email) {
+        if (email == null || email.trim().isEmpty()) {
+            return ResponseEntity.badRequest().body(UserErrorCode.USER_EMAIL_MISSING);
+        }
+        try {
+            userService.existsEmail(email);
+        } catch (UserErrorException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+        return ResponseEntity.ok().body(null);
+    }
+
     @Operation(summary = "비회원 비밀번호 찾기(구현 완료)")
     @PostMapping("/pwd")
     public ResponseEntity<?> findPassword(@Valid @RequestBody FindPasswordRequestDto req) {

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/controller/UserController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/controller/UserController.java
@@ -52,10 +52,10 @@ public class UserController {
         }
         try {
             userService.existsNickname(nickname);
+            return ResponseEntity.ok().body(null);
         } catch (UserErrorException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
-        return ResponseEntity.ok().body(null);
     }
 
     @Operation(summary = "이메일 검사 중복확인(구현 완료)", description = "소셜 가입 이메일 제외, 이메일 회원가입만 중복 체크")
@@ -66,10 +66,10 @@ public class UserController {
         }
         try {
             userService.existsEmail(email);
+            return ResponseEntity.ok().body(null);
         } catch (UserErrorException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
-        return ResponseEntity.ok().body(null);
     }
 
     @Operation(summary = "비회원 비밀번호 찾기(구현 완료)")
@@ -106,10 +106,10 @@ public class UserController {
     public ResponseEntity<?> signup(@Valid @RequestBody UserSignupRequestDto requestDto) {
         try {
             userService.signup(requestDto);
+            return ResponseEntity.ok().body(null);
         } catch (UserErrorException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
-        return ResponseEntity.ok().body(null);
     }
 
     @Operation(summary = "로그아웃(구현 완료)")
@@ -127,20 +127,32 @@ public class UserController {
     @Operation(summary = "회원 탈퇴(추가 수정 필요)", description = "개인정보 삭제 범위, 재가입 불가 구분용 정보 필요")
     @DeleteMapping
     public ResponseEntity<?> deleteUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-
-        userService.deleteUser(userDetails);
-        return ResponseEntity.ok().body(null);
+        try {
+            userService.deleteUser(userDetails);
+            return ResponseEntity.ok().body(null);
+        } catch (UserErrorException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
     }
 
     @Operation(summary = "자동로그인(구현 완료)")
     @PostMapping("/relogin")
     public ResponseEntity<?> reLogin(@Valid @RequestBody UserReLoginRequestDto requestDto) {
-        return ResponseEntity.ok().body(userService.reLogin(requestDto.getRefresh()));
+        try {
+            return ResponseEntity.ok().body(userService.reLogin(requestDto.getRefresh()));
+        } catch (UserErrorException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
     }
 
     @Operation(summary = "access Token 재발급(구현 완료)")
     @PostMapping("/reissue")
     public ResponseEntity<?> reissue(@Valid @RequestBody UserReissueRequestDto requestDto) {
-        return ResponseEntity.ok().body(userService.reissue(requestDto));
+        try {
+            return ResponseEntity.ok().body(userService.reissue(requestDto));
+        } catch (UserErrorException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserSignupRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserSignupRequestDto.java
@@ -23,6 +23,7 @@ public class UserSignupRequestDto {
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$", message = "영문, 숫자, 특수문자를 모두 포함하여 8글자 이상으로 입력해주세요.")
     private String password;
 
+    @NotBlank(message = "전화번호를 입력해주세요.")
     @Pattern(regexp = "^\\d{1,11}$")
     private String phone;
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/exception/UserErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/exception/UserErrorCode.java
@@ -14,7 +14,9 @@ public enum UserErrorCode implements StatusCode {
      */
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당하는 유저가 없습니다."),
     USER_NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다."),
+    User_EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 이메일입니다."),
     USER_NICKNAME_MISSING(HttpStatus.BAD_REQUEST, "닉네임을 입력해 주세요."),
+    USER_EMAIL_MISSING(HttpStatus.BAD_REQUEST, "이메일을 입력해 주세요."),
     USER_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일입니다."),
     USER_INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다."),
     DELETED_USER(HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다."),

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/exception/UserErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/exception/UserErrorCode.java
@@ -15,6 +15,7 @@ public enum UserErrorCode implements StatusCode {
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당하는 유저가 없습니다."),
     USER_NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다."),
     User_EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 이메일입니다."),
+    User_PHONE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 전화번호입니다."),
     USER_NICKNAME_MISSING(HttpStatus.BAD_REQUEST, "닉네임을 입력해 주세요."),
     USER_EMAIL_MISSING(HttpStatus.BAD_REQUEST, "이메일을 입력해 주세요."),
     USER_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일입니다."),

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/exception/UserErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/exception/UserErrorCode.java
@@ -14,11 +14,13 @@ public enum UserErrorCode implements StatusCode {
      */
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당하는 유저가 없습니다."),
     USER_NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다."),
-    User_EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 이메일입니다."),
-    User_PHONE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 전화번호입니다."),
+    USER_EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 이메일입니다."),
+    USER_PHONE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 전화번호입니다."),
     USER_NICKNAME_MISSING(HttpStatus.BAD_REQUEST, "닉네임을 입력해 주세요."),
     USER_EMAIL_MISSING(HttpStatus.BAD_REQUEST, "이메일을 입력해 주세요."),
     USER_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일입니다."),
+    USER_EMAIL_SUSPENDED(HttpStatus.BAD_REQUEST, "정지된 회원의 이메일은 사용할 수 없습니다."),
+    USER_EMAIL_TERMINATED(HttpStatus.BAD_REQUEST, "탈퇴한 회원의 이메일입니다. 탈퇴 후 재가입 할 수 없습니다."),
     USER_INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다."),
     DELETED_USER(HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다."),
     USER_SAME_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 동일합니다."),
@@ -32,7 +34,9 @@ public enum UserErrorCode implements StatusCode {
     /**
      * 403 FORBIDDEN
      */
-    USER_SUSPENDED(HttpStatus.FORBIDDEN, "정지된 회원입니다.");
+    USER_SUSPENDED(HttpStatus.FORBIDDEN, "정지된 회원입니다."),
+    USER_TERMINATED(HttpStatus.FORBIDDEN, "탈퇴한 회원입니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/repository/UserRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/repository/UserRepository.java
@@ -10,8 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
-    boolean existsByNickname(String nickname);
-
     Optional<User> findByOauthProviderAndEmail(String oauthId, String email);
 
     Optional<User> findByNickname(String username);
@@ -22,7 +20,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmailAndPhoneAndOauthProviderIsNull(String email, String phone);
 
+    Optional<User> findByEmailAndOauthProviderIsNullAndState(String email, int state);
+
     Optional<User> findByRefreshToken(String refreshToken);
 
-    boolean existsByEmailAndOauthProviderIsNull(String email);
+    boolean existsByNickname(String nickname);
+    
+    boolean existsByPhoneAndOauthProviderIsNull(String phone);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/repository/UserRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/repository/UserRepository.java
@@ -23,4 +23,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmailAndPhoneAndOauthProviderIsNull(String email, String phone);
 
     Optional<User> findByRefreshToken(String refreshToken);
+
+    boolean existsByEmailAndOauthProviderIsNull(String email);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
@@ -51,6 +51,7 @@ public class UserService {
     public void signup(UserSignupRequestDto requestDto) {
         existsNickname(requestDto.getNickname());
         existsEmail(requestDto.getEmail());
+        existsPhone(requestDto.getPhone());
 
         User user = User.builder()
             .email(requestDto.getEmail())
@@ -81,6 +82,12 @@ public class UserService {
     public void existsEmail(String email) {
         if (userRepository.existsByEmailAndOauthProviderIsNull(email)) {
             throw new UserErrorException(UserErrorCode.User_EMAIL_ALREADY_EXISTS);
+        }
+    }
+
+    public void existsPhone(String phone) {
+        if (userRepository.existsByEmailAndOauthProviderIsNull(phone)) {
+            throw new UserErrorException(UserErrorCode.User_PHONE_ALREADY_EXISTS);
         }
     }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
@@ -50,6 +50,7 @@ public class UserService {
     @Transactional
     public void signup(UserSignupRequestDto requestDto) {
         existsNickname(requestDto.getNickname());
+        existsEmail(requestDto.getEmail());
 
         User user = User.builder()
             .email(requestDto.getEmail())
@@ -74,6 +75,12 @@ public class UserService {
     public void existsNickname(String nickname) {
         if (userRepository.existsByNickname(nickname)) {
             throw new UserErrorException(UserErrorCode.USER_NICKNAME_ALREADY_EXISTS);
+        }
+    }
+
+    public void existsEmail(String email) {
+        if (userRepository.existsByEmailAndOauthProviderIsNull(email)) {
+            throw new UserErrorException(UserErrorCode.User_EMAIL_ALREADY_EXISTS);
         }
     }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
@@ -50,8 +50,8 @@ public class UserService {
     @Transactional
     public void signup(UserSignupRequestDto requestDto) {
         existsNickname(requestDto.getNickname());
-        existsEmail(requestDto.getEmail());
         existsPhone(requestDto.getPhone());
+        existsEmail(requestDto.getEmail());
 
         User user = User.builder()
             .email(requestDto.getEmail())
@@ -80,14 +80,20 @@ public class UserService {
     }
 
     public void existsEmail(String email) {
-        if (userRepository.existsByEmailAndOauthProviderIsNull(email)) {
-            throw new UserErrorException(UserErrorCode.User_EMAIL_ALREADY_EXISTS);
+        User user = userRepository.findByEmailAndOauthProviderIsNullAndState(email, 0)
+            .orElseThrow(null);
+        if (user == null) {
+            return;
+        } else if (user.getState() == 1) {
+            throw new UserErrorException(UserErrorCode.USER_EMAIL_SUSPENDED);
+        } else if (user.getState() == 2) {
+            throw new UserErrorException(UserErrorCode.USER_EMAIL_TERMINATED);
         }
     }
 
     public void existsPhone(String phone) {
-        if (userRepository.existsByEmailAndOauthProviderIsNull(phone)) {
-            throw new UserErrorException(UserErrorCode.User_PHONE_ALREADY_EXISTS);
+        if (userRepository.existsByPhoneAndOauthProviderIsNull(phone)) {
+            throw new UserErrorException(UserErrorCode.USER_PHONE_ALREADY_EXISTS);
         }
     }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
@@ -219,14 +219,13 @@ public class UserService {
     @Transactional
     public UserReissueResponseDto reissue(UserReissueRequestDto requestDto) {
         String accessToken = requestDto.getAccess();
+        if (!accessTokenBlackListService.isTokenBlackListed(accessToken)) {
+            accessTokenBlackListService.addBlackList(accessToken);
+        }
 
         User user = userRepository.findByRefreshToken(requestDto.getRefresh())
             .orElseThrow(() -> new UserErrorException(UserErrorCode.INVALID_REFRESH_TOKEN));
 
-        if (accessTokenBlackListService.isTokenBlackListed(accessToken)) {
-            throw new UserErrorException(UserErrorCode.INVALID_ACCESS_TOKEN);
-        }
-        accessTokenBlackListService.addBlackList(accessToken);
         return UserReissueResponseDto.toDto(reissueAccessToken(user.getUserId()));
     }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/security/JwtAuthenticationFilter.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/security/JwtAuthenticationFilter.java
@@ -62,6 +62,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
             if (1 == user.getState()) {
                 throw new UserErrorException(UserErrorCode.USER_SUSPENDED);
+            } else if (2 == user.getState()) {
+                throw new UserErrorException(UserErrorCode.USER_TERMINATED);
             }
 
             if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {


### PR DESCRIPTION
### ✅ PR 종류
- [x] 기능 추가
- [x] 버그 수정
- [] 리팩토링
- [] 테스트
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 소셜에서 사용할 토큰 검증 및 재발급 메소드 작성
- 회원가입 시 전화번호 필수 입력, 이메일 당 1개의 전화번호 사용가능
- 회원가입 시 이메일 중복 검사 api 작성
- 정지, 탈퇴된 회원의 이메일로 가입, 로그인하려는 경우 오류메시지 전달
- 액세스 토큰 재발급 시 401 오류 해결
---
### 📖 참고 사항






