### PR TITLE
마이페이지, 배송지 조회 API 변경 / Exception 추가

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/controller/DeliveryController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/controller/DeliveryController.java
@@ -1,0 +1,27 @@
+package dutchiepay.backend.domain.delivery.controller;
+
+import dutchiepay.backend.domain.delivery.service.DeliveryService;
+import dutchiepay.backend.global.security.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "배송지 API", description = "프로필 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/delivery")
+public class DeliveryController {
+    private final DeliveryService deliveryService;
+
+    @Operation(summary = "배송지 조회")
+    @GetMapping("")
+    public ResponseEntity<?> getMyDelivery(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.ok().body(deliveryService.getDelivery(userDetails.getUser()));
+    }
+
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/dto/GetMyDeliveryResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/dto/GetMyDeliveryResponseDto.java
@@ -1,0 +1,41 @@
+package dutchiepay.backend.domain.delivery.dto;
+
+import dutchiepay.backend.entity.Address;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetMyDeliveryResponseDto {
+    private Long addressId;
+    private String addressName;
+    private String name;
+    private String phone;
+    private String address;
+    private String detail;
+    private String zipCode;
+    private boolean isDefault;
+
+    public static List<GetMyDeliveryResponseDto> from(List<Address> addressList) {
+        List<GetMyDeliveryResponseDto> addressResponse = new ArrayList<>();
+
+        for (Address address : addressList) {
+            addressResponse.add(GetMyDeliveryResponseDto.builder()
+                    .addressId(address.getAddressId())
+                    .addressName(address.getAddressName())
+                    .name(address.getReceiver())
+                    .phone(address.getPhone())
+                    .address(address.getAddressInfo())
+                    .detail(address.getDetail())
+                    .zipCode(address.getZipCode())
+                    .isDefault(address.getIsDefault())
+                    .build());
+        }
+
+        return addressResponse;
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/service/DeliveryService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/service/DeliveryService.java
@@ -1,0 +1,22 @@
+package dutchiepay.backend.domain.delivery.service;
+
+import dutchiepay.backend.domain.delivery.dto.GetMyDeliveryResponseDto;
+import dutchiepay.backend.domain.profile.repository.AddressRepository;
+import dutchiepay.backend.entity.Address;
+import dutchiepay.backend.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryService {
+    private final AddressRepository addressRepository;
+
+    public List<GetMyDeliveryResponseDto> getDelivery(User user) {
+        List<Address> addressList = addressRepository.findAllByUser(user);
+
+        return GetMyDeliveryResponseDto.from(addressList);
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/MyPageResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/MyPageResponseDto.java
@@ -1,65 +1,22 @@
 package dutchiepay.backend.domain.profile.dto;
 
-import dutchiepay.backend.entity.Address;
 import dutchiepay.backend.entity.User;
 import lombok.*;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MyPageResponseDto {
-    private List<UserAddress> deliveryAddress;
     private String phone;
-    private Long coupon;
-    private Long order;
     private String email;
 
-    public static MyPageResponseDto from(User user, List<Address> addressList, Long couponCount, Long orderCount) {
-        List<UserAddress> addressResponse = new ArrayList<>();
-
-        for (Address a : addressList) {
-            addressResponse.add(UserAddress.from(a));
-        }
+    public static MyPageResponseDto from(User user) {
 
         return MyPageResponseDto.builder()
-                .deliveryAddress(addressResponse)
                 .phone(user.getPhone())
-                .coupon(couponCount)
-                .order(orderCount)
                 .email(user.getEmail())
                 .build();
-    }
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class UserAddress {
-        private Long addressId;
-        private String addressName;
-        private String name;
-        private String phone;
-        private String address;
-        private String detail;
-        private String zipCode;
-        private boolean isDefault;
-
-        public static UserAddress from(Address address) {
-            return UserAddress.builder()
-                    .addressId(address.getAddressId())
-                    .addressName(address.getAddressName())
-                    .name(address.getReceiver())
-                    .phone(address.getPhone())
-                    .address(address.getAddressInfo())
-                    .detail(address.getDetail())
-                    .zipCode(address.getZipCode())
-                    .isDefault(address.getIsDefault())
-                    .build();
-        }
     }
 
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/exception/ProfileErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/exception/ProfileErrorCode.java
@@ -19,6 +19,7 @@ public enum ProfileErrorCode implements StatusCode {
     INVALID_USER_ORDER_REVIEW(HttpStatus.BAD_REQUEST, "자신이 구매한 상품에만 댓글을 달 수 있습니다."),
     INVALID_USER_ORDER_ASK(HttpStatus.BAD_REQUEST, "자신이 구매한 상품에만 문의를 달 수 있습니다."),
     INVALID_ADDRESS(HttpStatus.BAD_REQUEST, "주소 정보가 없습니다."),
+    ADDRESS_COUNT_LIMIT(HttpStatus.BAD_REQUEST, "주소는 최대 5개까지 등록 가능합니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/UsersAddressRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/UsersAddressRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UsersAddressRepository extends JpaRepository<UsersAddress, Long> {
     void deleteByUserAndAddress(User user, Address address);
+
+    Long countByUser(User user);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
@@ -32,11 +32,7 @@ public class ProfileService {
     private final UsersAddressRepository usersAddressRepository;
 
     public MyPageResponseDto myPage(User user) {
-        List<Address> addressList = addressRepository.findAllByUser(user);
-        Long couponCount = usersCouponRepository.countByUser(user);
-        Long orderCount = ordersRepository.countByUserPurchase(user, "결제 완료");
-
-        return MyPageResponseDto.from(user, addressList, couponCount, orderCount);
+        return MyPageResponseDto.from(user);
     }
 
     public List<MyGoodsResponseDto> getMyGoods(User user, Long page, Long limit) {
@@ -177,6 +173,10 @@ public class ProfileService {
 
     @Transactional
     public void addAddress(User user, @Valid CreateAddressRequestDto req) {
+        if (usersAddressRepository.countByUser(user) >= 5) {
+            throw new ProfileErrorException(ProfileErrorCode.ADDRESS_COUNT_LIMIT);
+        }
+
         Address newAddress = Address.builder()
                 .addressName(req.getAddressName())
                 .receiver(req.getName())

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/controller/UserController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/controller/UserController.java
@@ -45,8 +45,9 @@ public class UserController {
     }
 
     @Operation(summary = "닉네임 검사 중복확인(구현 완료)")
-    @GetMapping
+    @GetMapping(value = "", params = "nickname")
     public ResponseEntity<?> isExistNickname(@RequestParam(required = false) String nickname) {
+        System.out.println("nickname = " + nickname);
         if (nickname == null || nickname.trim().isEmpty()) {
             return ResponseEntity.badRequest().body(UserErrorCode.USER_NICKNAME_MISSING);
         }
@@ -59,8 +60,9 @@ public class UserController {
     }
 
     @Operation(summary = "이메일 검사 중복확인(구현 완료)", description = "소셜 가입 이메일 제외, 이메일 회원가입만 중복 체크")
-    @GetMapping
+    @GetMapping(value = "", params = "email")
     public ResponseEntity<?> isExistEmail(@RequestParam(required = false) String email) {
+        System.out.println("email = " + email);
         if (email == null || email.trim().isEmpty()) {
             return ResponseEntity.badRequest().body(UserErrorCode.USER_EMAIL_MISSING);
         }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserChangePasswordRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserChangePasswordRequestDto.java
@@ -8,4 +8,5 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserChangePasswordRequestDto {
     private String password;
+    private String newPassword;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/exception/UserErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/exception/UserErrorCode.java
@@ -24,6 +24,7 @@ public enum UserErrorCode implements StatusCode {
     USER_INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다."),
     DELETED_USER(HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다."),
     USER_SAME_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 동일합니다."),
+    SAME_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 새로운 비밀번호가 같습니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
@@ -100,6 +100,12 @@ public class UserService {
     public FindEmailResponseDto findEmail(FindEmailRequestDto req) {
         User user = userUtilService.commonUserFindByPhone(req.getPhone());
 
+        if (user.getState() == 1) {
+            throw new UserErrorException(UserErrorCode.USER_SUSPENDED);
+        } else if (user.getState() == 2) {
+            throw new UserErrorException(UserErrorCode.USER_TERMINATED);
+        }
+
         return FindEmailResponseDto.of(userUtilService.maskEmail(user.getEmail()));
     }
 
@@ -121,6 +127,10 @@ public class UserService {
 
     @Transactional
     public void changeUserPassword(User user, UserChangePasswordRequestDto req) {
+        if (req.getPassword().equals(req.getNewPassword())) {
+            throw new UserErrorException(UserErrorCode.SAME_PASSWORD);
+        }
+
         if (passwordEncoder.matches(req.getPassword(), user.getPassword())) {
             throw new UserErrorException(UserErrorCode.USER_SAME_PASSWORD);
         }


### PR DESCRIPTION
### ✅ PR 종류
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 마이페이지 조회 API 변경 : 기존에 배송지와 쿠폰, 주문까지 나오던 api를 이메일과 휴대폰번호만 나오도록 하였습니다.
- 배송지 조회 API 추가 : 마이페이지 조회에 존재하던 부분을 별도의 Delivery 도메인으로 변경했습니다
- Exception 추가 : 회원 비밀번호 변경 시 기존 비밀번호와 새 비밀번호가 같에 들어오는 경우 예외 처리, 이메일 찾기 시에 정지된 회원과 탈퇴한 회원의 경우 예외처리를 하였습니다.
- 비밀번호, 이메일 찾기 컨트롤러 params 추가 : 기존에 params을 붙이지 않아 에러가 나던 현상을 해결했습니다.
---
### 📖 참고 사항
- 추후 배송지 추가 및 삭제 API를 Delivery 도메인으로 변경 예정
- 비밀번호, 이메일 찾기 시 401에러 발생 : 현재는 원인 찾지 못함







