### PR TITLE
fix | 소셜 로그인 로직 수정

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/handler/CustomOAuth2SuccessHandler.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/handler/CustomOAuth2SuccessHandler.java
@@ -51,9 +51,7 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
         String accessToken = jwtUtil.createAccessToken(user.getUserId());
 //        sendResponse(response, UserLoginResponseDto.toDto(user, accessToken));
 
-        String html = "<html><body><script>const parentOrigin = window.location.hostname === 'localhost'\n" +
-                "  ? 'http://localhost:3000'  // 개발 환경\n" +
-                "  : 'https://d2m4bskl88m9ql.cloudfront.net';  // 실제 배포 환경\n" +
+        String html = "<html><body><script>const parentOrigin = 'http://localhost:3000'\n" +
                 "\n" +
                 "window.opener.postMessage(\n" +
                 "  {\n" +
@@ -67,7 +65,7 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
                 "    isCertified: " + (user.getPhone() == null ? "false" : "true") + "\n" +
                 "  },\n" +
                 "  parentOrigin\n" +
-                "); console.log('로그인 성공'); console.log(parentOrigin); console.log(refreshToken); </script></body></html>";
+                "); console.log('로그인 성공'); console.log(parentOrigin); </script></body></html>";
         response.setContentType("text/html");
         response.getWriter().write(html);
 


### PR DESCRIPTION
- successHandler 로컬호스트 수정

### ✅ PR 종류
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- parentOrigin이 localhost여야하는데 배포 주소로 들어가서 배포 주소 삭제
---
### 📖 참고 사항
- 카카오로 로그인할 때 oauthProvider가 계속 닉네임으로 들어가네요 ㅎㅎ... 수정 필요







