### PR TITLE
feat | 소셜 로그인 수정

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/oauth/controller/OauthController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/oauth/controller/OauthController.java
@@ -1,13 +1,9 @@
 package dutchiepay.backend.domain.oauth.controller;
 
-import dutchiepay.backend.domain.user.dto.UserLoginResponseDto;
 import dutchiepay.backend.domain.user.service.UserService;
-import dutchiepay.backend.global.oauth.service.CustomOAuth2UserService;
 import dutchiepay.backend.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -17,23 +13,16 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class OauthController {
 
-    private final CustomOAuth2UserService customOAuth2UserService;
     private final UserService userService;
 
-    @Operation(summary = "소셜 로그인(구현중)")
+    @Operation(summary = "소셜 로그인(구현 완료)")
     @GetMapping("/signup")
     public String signup(@RequestParam String type) {
 
         return "redirect:/oauth2/authorization/" + type;
     }
 
-    @Operation(summary = "소셜 로그인 완료 후 회원 정보 요청받을 controller")
-    @PostMapping("/users")
-    public ResponseEntity<UserLoginResponseDto> userInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return ResponseEntity.ok(userService.userInfo(userDetails));
-    }
-
-    @Operation(summary = "소셜 회원 탈퇴(구현중)")
+    @Operation(summary = "소셜 회원 탈퇴(구현 완료)")
     @DeleteMapping
     public String unlink(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam String type){
         if (type.equals("kakao")) {
@@ -41,9 +30,6 @@ public class OauthController {
         } else {
             userService.unlinkNaver(userDetails);
         }
-
-        userService.deleteUser(userDetails);
         return "redirect:/";
     }
-
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
@@ -140,6 +140,7 @@ public class UserService {
         userRepository.save(user);
     }
 
+    @Transactional
     public void unlinkKakao(UserDetailsImpl userDetails) {
         OAuth2AuthorizedClient authorizedClient = oauthService.loadAuthorizedClient(
             "kakao", // OAuth2 로그인 제공자 이름 (예: "google", "naver")
@@ -167,8 +168,11 @@ public class UserService {
             String.class                     // 응답 타입
         );
 
+        userRepository.findByOauthProviderAndEmail(userDetails.getOAuthProvider(), userDetails.getEmail())
+                .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_EMAIL_NOT_FOUND)).delete();
     }
 
+    @Transactional
     public void unlinkNaver(UserDetailsImpl userDetails) {
 
         OAuth2AuthorizedClient authorizedClient = oauthService.loadAuthorizedClient(
@@ -195,6 +199,9 @@ public class UserService {
             null,                          // HttpEntity
             String.class                     // 응답 타입
         );
+
+        userRepository.findByOauthProviderAndEmail(userDetails.getOAuthProvider(), userDetails.getEmail())
+                .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_EMAIL_NOT_FOUND)).delete();
     }
 
     @Transactional

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/dto/OAuthAttribute.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/dto/OAuthAttribute.java
@@ -28,8 +28,6 @@ public class OAuthAttribute {
         this.nickname = nickname;
         this.oauthId = oauthId;
         this.oauthProvider = oauthProvider;
-        System.out.println("========Constructor==========");
-        System.out.println("This.oauthProvider:  " + this.oauthProvider);
     }
 
     public static OAuthAttribute of(String userNameAttributeName, Map<String, Object> attributes, String registrationId) {
@@ -68,8 +66,6 @@ public class OAuthAttribute {
     }
 
     public User toEntity() {
-        System.out.println("=========toEntity==========");
-        System.out.println("oauthProvider   " + oauthProvider);
         return User.builder()
                 .email(email)
                 .nickname(nickname)


### PR DESCRIPTION
### ✅ PR 종류
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 테스트
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 소셜 로그인 성공 후 응답 값 암호화하여 전달
- 불필요한 System.out 삭제
- unlink 후 deleteUser 메서드를 controller에서 호출하던 것을 해당 메서드에서 직접 삭제하도록 변경
- OauthController에서 사용하지 않는 엔드포인트 삭제
- SuccessHandler에서 사용하지 않는 메서드 삭제
---
### 📖 참고 사항
![image](https://github.com/user-attachments/assets/02f71859-32f8-4de5-ba5c-11d3aae1936c)
- 암호화 과정에 있어서 변수가 필수로 static이어야 하는데, @Value 어노테이션은 construct 후에 값을 주입하여 static이 불가하였습니다. 따라서 현재 코드처럼 작성이 되었는데, 더 나은 방법이 있다면 말씀해주세요. 해당 방법은 멀티스레드 환경에서 이슈가 있을 수 있다고 합니다. 해당 환경 변수 값은 notion과 aws에 작성해놓았습니다.

![image](https://github.com/user-attachments/assets/e4141d80-3dda-4786-8823-3cc194014190)
- 기존 OAuthController에서 userService.deleteUser을 호출하던 것에서 unlink 메서드에서 직접 deleteUser 로직을 수행하도록 변경했습니다. deleteUser 메서드를 삭제하려고 했는데 사용처가 있어서 그대로 두었습니다. 현재 deleteUser 메서드에서 user을 찾을 때 email로만 찾고 있어서 해당 부분 수정 필요해 보입니다.

- System.out.prinln으로 출력하고 있는 코드가 있습니다. 해당 부분 삭제 부탁드립니다.






