### PR TITLE
프로필 API 추가 구현 / 마이페이지 조회 시 휴대폰 번호 중간자리 마스킹

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/dto/DeleteDeliveryRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/dto/DeleteDeliveryRequestDto.java
@@ -8,6 +8,6 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DeleteDeliveryRequestDto {
-    @NotNull(message = "배송지 ID를 입력해주세요.")
+    @NotNull(message = "배송지번호를 입력해주세요.")
     private Long addressId;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/controller/OrdersController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/controller/OrdersController.java
@@ -1,33 +1,44 @@
 package dutchiepay.backend.domain.order.controller;
 
+import dutchiepay.backend.domain.order.dto.CancelPurchaseRequestDto;
+import dutchiepay.backend.domain.order.dto.ConfirmPurchaseRequestDto;
+import dutchiepay.backend.domain.order.dto.ExchangeRequestDto;
+import dutchiepay.backend.domain.order.service.OrdersService;
+import dutchiepay.backend.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/orders")
 public class OrdersController {
+    private final OrdersService ordersService;
 
-    @Operation(summary = "환불/교환 신청 (구현 중)")
+    @Operation(summary = "환불/교환 신청 (구현 완료)")
     @PostMapping("/exchange")
-    public ResponseEntity<?> applyExchange() {
-        return ResponseEntity.ok().body(null);
+    public ResponseEntity<?> applyExchange(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                           @Valid @RequestBody ExchangeRequestDto req) {
+        ordersService.applyExchange(userDetails.getUser(), req);
+        return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "상품 구매 확정 (구현 중)")
+    @Operation(summary = "상품 구매 확정 (구현 완료)")
     @PatchMapping("/purchase")
-    public ResponseEntity<?> confirmPurchase() {
-        return ResponseEntity.ok().body(null);
+    public ResponseEntity<?> confirmPurchase(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                             @Valid @RequestBody ConfirmPurchaseRequestDto req) {
+        ordersService.confirmPurchase(userDetails.getUser(), req.getOrderId());
+        return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "구매 취소 (구현 중)")
+    @Operation(summary = "구매 취소 (구현 완료)")
     @PatchMapping("/exchange")
-    public ResponseEntity<?> cancelExchange() {
-        return ResponseEntity.ok().body(null);
+    public ResponseEntity<?> cancelPurchase(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                            @Valid @RequestBody CancelPurchaseRequestDto req) {
+        ordersService.cancelPurchase(userDetails.getUser(), req);
+        return ResponseEntity.ok().build();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/dto/CancelPurchaseRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/dto/CancelPurchaseRequestDto.java
@@ -1,0 +1,13 @@
+package dutchiepay.backend.domain.order.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CancelPurchaseRequestDto {
+    @NotBlank(message = "주문 ID를 입력해주세요.")
+    private Long orderId;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/dto/ConfirmPurchaseRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/dto/ConfirmPurchaseRequestDto.java
@@ -1,0 +1,13 @@
+package dutchiepay.backend.domain.order.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConfirmPurchaseRequestDto {
+    @NotBlank(message = "주문 ID를 입력해주세요.")
+    private Long orderId;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/dto/ExchangeRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/dto/ExchangeRequestDto.java
@@ -1,0 +1,18 @@
+package dutchiepay.backend.domain.order.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExchangeRequestDto {
+    @NotBlank(message = "교환 요청 타입을 입력해주세요.")
+    private String type;
+    @NotBlank(message = "주문 ID를 입력해주세요.")
+    private Long orderId;
+    @NotBlank(message = "교환 사유를 입력해주세요.")
+    private String reason;
+    private String detail;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/exception/OrdersErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/exception/OrdersErrorCode.java
@@ -1,0 +1,25 @@
+package dutchiepay.backend.domain.order.exception;
+
+import dutchiepay.backend.global.exception.StatusCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum OrdersErrorCode implements StatusCode {
+    /**
+     * 400 BAD_REQUEST
+     */
+    INVALID_ORDER(HttpStatus.BAD_REQUEST, "주문정보를 찾을 수 없습니다."),
+    INVALID_EXCHANGE_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 교환 요청 타입입니다."),
+
+    /**
+     * 401 UNAUTHORIZED
+     */
+    ORDER_USER_MISS_MATCH(HttpStatus.UNAUTHORIZED, "주문자 정보가 일치하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/exception/OrdersErrorException.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/exception/OrdersErrorException.java
@@ -1,0 +1,19 @@
+package dutchiepay.backend.domain.order.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OrdersErrorException extends RuntimeException {
+    private final OrdersErrorCode ordersErrorCode;
+
+    public OrdersErrorException(OrdersErrorCode ordersErrorCode) {
+        super(ordersErrorCode.getMessage());
+        this.ordersErrorCode = ordersErrorCode;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("OrdersErrorException(code=%s, message=%s)",
+                ordersErrorCode.name(), ordersErrorCode.getMessage());
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/repository/RefundRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/repository/RefundRepository.java
@@ -1,0 +1,7 @@
+package dutchiepay.backend.domain.order.repository;
+
+import dutchiepay.backend.entity.Refund;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefundRepository extends JpaRepository<Refund, Long> {
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/repository/ReviewRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/repository/ReviewRepository.java
@@ -3,6 +3,8 @@ package dutchiepay.backend.domain.order.repository;
 import dutchiepay.backend.entity.Review;
 import dutchiepay.backend.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +13,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findAllByUser(User user);
 
     Optional<Review> findByUserAndReviewId(User user, Long reviewId);
+
+    @Modifying
+    @Query("update Review r set r.deletedAt = current_timestamp where r = ?1")
+    void softDelete(Review review);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrdersService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrdersService.java
@@ -1,0 +1,70 @@
+package dutchiepay.backend.domain.order.service;
+
+import dutchiepay.backend.domain.order.dto.CancelPurchaseRequestDto;
+import dutchiepay.backend.domain.order.dto.ExchangeRequestDto;
+import dutchiepay.backend.domain.order.exception.OrdersErrorCode;
+import dutchiepay.backend.domain.order.exception.OrdersErrorException;
+import dutchiepay.backend.domain.order.repository.OrdersRepository;
+import dutchiepay.backend.domain.order.repository.RefundRepository;
+import dutchiepay.backend.entity.Orders;
+import dutchiepay.backend.entity.Refund;
+import dutchiepay.backend.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrdersService {
+    private final OrdersRepository ordersRepository;
+    private final RefundRepository refundRepository;
+
+    @Transactional
+    public void confirmPurchase(User user, Long orderId) {
+        Orders order = ordersRepository.findById(orderId)
+                .orElseThrow(() -> new OrdersErrorException(OrdersErrorCode.INVALID_ORDER));
+
+        if (order.getUser() != user) {
+            throw new OrdersErrorException(OrdersErrorCode.ORDER_USER_MISS_MATCH);
+        }
+
+        order.confirmPurchase();
+    }
+
+    @Transactional
+    public void applyExchange(User user, ExchangeRequestDto req) {
+        Orders order = ordersRepository.findById(req.getOrderId())
+                .orElseThrow(() -> new OrdersErrorException(OrdersErrorCode.INVALID_ORDER));
+
+        if (order.getUser() != user) {
+            throw new OrdersErrorException(OrdersErrorCode.ORDER_USER_MISS_MATCH);
+        }
+
+        if (!req.getType().equals("교환") && !req.getType().equals("환불")) {
+            throw new OrdersErrorException(OrdersErrorCode.INVALID_EXCHANGE_TYPE);
+        }
+
+        Refund newRefund = Refund.builder()
+                .user(user)
+                .store(order.getProduct().getStoreId())
+                .orders(order)
+                .category(req.getType())
+                .reason(req.getReason())
+                .detail(req.getDetail())
+                .build();
+
+        refundRepository.save(newRefund);
+    }
+
+    @Transactional
+    public void cancelPurchase(User user, CancelPurchaseRequestDto req) {
+        Orders order = ordersRepository.findById(req.getOrderId())
+                .orElseThrow(() -> new OrdersErrorException(OrdersErrorCode.INVALID_ORDER));
+
+        if (order.getUser() != user) {
+            throw new OrdersErrorException(OrdersErrorCode.ORDER_USER_MISS_MATCH);
+        }
+
+        order.cancelPurchase();
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/controller/ProfileController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/controller/ProfileController.java
@@ -131,7 +131,7 @@ public class ProfileController {
      * DELETE
      */
     @Operation(summary = "후기 삭제 (구현 완료)")
-    @DeleteMapping("/asks")
+    @DeleteMapping("/reviews")
     public ResponseEntity<?> deleteReview(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                        @Valid @RequestBody DeleteReviewRequestDto req) {
         profileService.deleteReview(userDetails.getUser(), req.getReviewId());

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/controller/ProfileController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/controller/ProfileController.java
@@ -132,9 +132,17 @@ public class ProfileController {
      */
     @Operation(summary = "후기 삭제 (구현 완료)")
     @DeleteMapping("/asks")
+    public ResponseEntity<?> deleteReview(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                       @Valid @RequestBody DeleteReviewRequestDto req) {
+        profileService.deleteReview(userDetails.getUser(), req.getReviewId());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "문의 삭제 (구현 완료)")
+    @DeleteMapping("/asks")
     public ResponseEntity<?> deleteAsk(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                        @Valid @RequestBody DeleteAskRequestDto req) {
-        profileService.deleteAsk(userDetails.getUser(), req.getReviewId());
+        profileService.deleteAsk(userDetails.getUser(), req.getAskId());
         return ResponseEntity.ok().build();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/CreateAskRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/CreateAskRequestDto.java
@@ -9,9 +9,9 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CreateAskRequestDto {
-    @NotBlank(message = "주문번호를 입력해주세요.")
+    @NotBlank(message = "주문 ID를 입력해주세요.")
     private Long orderId;
-    @NotBlank(message = "질문 내용을 입력해주세요.")
+    @NotBlank(message = "문의 내용을 입력해주세요.")
     private String content;
     @NotNull(message = "비밀글 여부를 입력해주세요.")
     private Boolean isSecret;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/DeleteAskRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/DeleteAskRequestDto.java
@@ -8,6 +8,6 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DeleteAskRequestDto {
-    @NotBlank(message = "리뷰 아이디를 입력해주세요.")
+    @NotBlank(message = "후기 ID를 입력해주세요.")
     private Long reviewId;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/DeleteReviewRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/DeleteReviewRequestDto.java
@@ -7,7 +7,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DeleteAskRequestDto {
-    @NotBlank(message = "후기 ID를 입력해주세요.")
-    private Long askId;
+public class DeleteReviewRequestDto {
+    @NotBlank(message = "리뷰 ID를 입력해주세요.")
+    private Long reviewId;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/MyPageResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/MyPageResponseDto.java
@@ -12,9 +12,10 @@ public class MyPageResponseDto {
     private String email;
 
     public static MyPageResponseDto from(User user) {
+        String maskingPhone = user.getPhone().replaceAll("(\\d{2,3})(\\d{3,4})(\\d{4})", "$1-****-$3");
 
         return MyPageResponseDto.builder()
-                .phone(user.getPhone())
+                .phone(maskingPhone)
                 .email(user.getEmail())
                 .build();
     }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/exception/ProfileErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/exception/ProfileErrorCode.java
@@ -22,7 +22,8 @@ public enum ProfileErrorCode implements StatusCode {
     /**
      * 401 UNAUTHORIZED
      */
-    DELETE_USER_MISSMATCH(HttpStatus.UNAUTHORIZED, "본인만 문의 삭제를 할 수 있습니다.");
+    DELETE_ASK_USER_MISSMATCH(HttpStatus.UNAUTHORIZED, "본인만 문의 삭제를 할 수 있습니다."),
+    DELETE_REVIEW_USER_MISSMATCH(HttpStatus.UNAUTHORIZED, "본인만 문의 삭제를 할 수 있습니다.");
 
     /**
      * 403 FORBIDDEN

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
@@ -9,6 +9,7 @@ import dutchiepay.backend.domain.profile.repository.ProfileRepository;
 import dutchiepay.backend.domain.user.repository.UserRepository;
 import dutchiepay.backend.entity.*;
 import jakarta.transaction.Transactional;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -145,9 +146,19 @@ public class ProfileService {
         Ask ask = askRepository.findById(askId).orElseThrow(() -> new ProfileErrorException(ProfileErrorCode.INVALID_ASK));
 
         if (ask.getUser() != user) {
-            throw new ProfileErrorException(ProfileErrorCode.DELETE_USER_MISSMATCH);
+            throw new ProfileErrorException(ProfileErrorCode.DELETE_ASK_USER_MISSMATCH);
         }
 
         askRepository.softDelete(ask);
+    }
+
+    public void deleteReview(User user, Long reviewId) {
+        Review review = reviewRepository.findById(reviewId).orElseThrow(() -> new ProfileErrorException(ProfileErrorCode.INVALID_REVIEW));
+
+        if (review.getUser() != user) {
+            throw new ProfileErrorException(ProfileErrorCode.DELETE_REVIEW_USER_MISSMATCH);
+        }
+
+        reviewRepository.softDelete(review);
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserSignupRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserSignupRequestDto.java
@@ -24,7 +24,7 @@ public class UserSignupRequestDto {
     private String password;
 
     @NotBlank(message = "전화번호를 입력해주세요.")
-    @Pattern(regexp = "^\\d{1,11}$")
+    @Pattern(regexp = "^\\d{1,11}$", message = "전화번호는 1자리 이상 11자리 이하 숫자여야 합니다.")
     private String phone;
 
     @NotBlank(message = "닉네임을 입력해주세요.")

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Orders.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Orders.java
@@ -56,4 +56,12 @@ public class Orders extends Auditing {
 
     @Column(nullable = false)
     private int amount;
+
+    public void confirmPurchase() {
+        this.state = "주문확정";
+    }
+
+    public void cancelPurchase() {
+        this.state = "주문취소";
+    }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Refund.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Refund.java
@@ -29,14 +29,13 @@ public class Refund extends Auditing {
     private Orders orders;
 
     @Column(length = 10, nullable = false)
-    private String type;
-
+    private String category;
+    
     @Column(length = 500, nullable = false)
     private String reason;
 
     private String detail;
 
-    @Column(length = 10, nullable = false)
-    private String category;
+
 
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Refund.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Refund.java
@@ -28,6 +28,7 @@ public class Refund extends Auditing {
     @JoinColumn(name = "order_id")
     private Orders orders;
 
+    @Column(length = 10, nullable = false)
     private String type;
 
     @Column(length = 500, nullable = false)

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Refund.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Refund.java
@@ -30,7 +30,7 @@ public class Refund extends Auditing {
 
     @Column(length = 10, nullable = false)
     private String category;
-    
+
     @Column(length = 500, nullable = false)
     private String reason;
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Refund.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Refund.java
@@ -28,6 +28,8 @@ public class Refund extends Auditing {
     @JoinColumn(name = "order_id")
     private Orders orders;
 
+    private String type;
+
     @Column(length = 500, nullable = false)
     private String reason;
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/exception/CustomExceptionHandler.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/exception/CustomExceptionHandler.java
@@ -1,6 +1,7 @@
 package dutchiepay.backend.global.exception;
 
 import dutchiepay.backend.domain.delivery.exception.DeliveryErrorException;
+import dutchiepay.backend.domain.order.exception.OrdersErrorException;
 import dutchiepay.backend.domain.profile.exception.ProfileErrorException;
 import dutchiepay.backend.domain.user.exception.UserErrorException;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +41,13 @@ public class CustomExceptionHandler {
         log.warn("handleDeliveryErrorException : {}", e.getMessage());
         final ErrorMessage message = ErrorMessage.of(e.getMessage());
         return ResponseEntity.status(e.getDeliveryErrorCode().getHttpStatus()).body(message);
+    }
+
+    @ExceptionHandler(OrdersErrorException.class)
+    protected ResponseEntity<?> handleOrdersErrorException(OrdersErrorException e) {
+        log.warn("handleOrdersErrorException : {}", e.getMessage());
+        final ErrorMessage message = ErrorMessage.of(e.getMessage());
+        return ResponseEntity.status(e.getOrdersErrorCode().getHttpStatus()).body(message);
     }
 
     /**


### PR DESCRIPTION
### ⚡이슈 번호
resolve #38 

---
### ✅ PR 종류
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 문의 삭제 API 구현
- 상품 구매 확정 API 구현
- 환불/교환 신청 API 구현
- 구매 취소 API 구현
- 마이페이지 조회 시 전화번호 중간부분 마스킹 처리
- 오류 메시지 일부를 수정하였습니다
---
### 📖 참고 사항
이번에 추가한 API의 경우, Order 엔티티가 정상적으로 작동할 때 테스트가 진행될 수 있을 것 같아서 현재는 큰 틀의 기능을 추가해두었다 정도로 생각해주시면 감사하겠습니다.