### PR TITLE
배송지 API 문제 해결 / 이메일 찾기 401오류 해결

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/exception/DeliveryErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/exception/DeliveryErrorCode.java
@@ -13,6 +13,7 @@ public enum DeliveryErrorCode implements StatusCode {
      * 400 BAD_REQUEST
      */
     INVALID_ADDRESS(HttpStatus.BAD_REQUEST, "주소 정보가 없습니다."),
+    CANNOT_CHANGE_DEFAULT_ADDRESS(HttpStatus.BAD_REQUEST, "기본 배송지는 변경할 수 없습니다."),
     ADDRESS_COUNT_LIMIT(HttpStatus.BAD_REQUEST, "주소는 최대 5개까지 등록 가능합니다.");
 
     /**

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/repository/QAddressRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/repository/QAddressRepositoryImpl.java
@@ -36,7 +36,8 @@ public class QAddressRepositoryImpl implements QAddressRepository{
                 .selectFrom(qAddress)
                 .join(qUsersAddress)
                 .on(qUsersAddress.address.eq(qAddress))
-                .where(qUsersAddress.user.eq(user))
+                .where(qUsersAddress.user.eq(user)
+                        .and(qAddress.isDefault.eq(false)))
                 .orderBy(qAddress.createdAt.asc())
                 .fetchFirst();
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/service/DeliveryService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/service/DeliveryService.java
@@ -29,7 +29,9 @@ public class DeliveryService {
 
     @Transactional
     public CreateDeliveryResponseDto addDelivery(User user, CreateDeliveryRequestDto req) {
-        if (usersAddressRepository.countByUser(user) >= 5) {
+        Long count = usersAddressRepository.countByUser(user);
+
+        if (count >= 5) {
             throw new DeliveryErrorException(DeliveryErrorCode.ADDRESS_COUNT_LIMIT);
         }
 
@@ -40,10 +42,10 @@ public class DeliveryService {
                 .addressInfo(req.getAddress())
                 .detail(req.getDetail())
                 .zipCode(req.getZipCode())
-                .isDefault(req.getIsDefault())
+                .isDefault(count == 0 ? Boolean.TRUE : req.getIsDefault())
                 .build();
 
-        if (newAddress.getIsDefault().equals(Boolean.TRUE)) {
+        if (count != 0 && newAddress.getIsDefault().equals(Boolean.TRUE)) {
             addressRepository.changeIsDefaultTrueToFalse(user);
         }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/service/DeliveryService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/service/DeliveryService.java
@@ -66,6 +66,10 @@ public class DeliveryService {
         Address address = addressRepository.findById(req.getAddressId())
                 .orElseThrow(() -> new DeliveryErrorException(DeliveryErrorCode.INVALID_ADDRESS));
 
+        if (address.getIsDefault().equals(Boolean.TRUE) && req.getIsDefault().equals(Boolean.FALSE)) {
+            throw new DeliveryErrorException(DeliveryErrorCode.CANNOT_CHANGE_DEFAULT_ADDRESS);
+        }
+        
         if (req.getIsDefault().equals(Boolean.TRUE)) {
             addressRepository.changeIsDefaultTrueToFalse(user);
         }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/service/DeliveryService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/delivery/service/DeliveryService.java
@@ -79,11 +79,12 @@ public class DeliveryService {
         Address address = addressRepository.findById(req.getAddressId())
                 .orElseThrow(() -> new DeliveryErrorException(DeliveryErrorCode.INVALID_ADDRESS));
 
+        usersAddressRepository.deleteByUserAndAddress(user, address);
+        addressRepository.delete(address);
+
         if (address.getIsDefault().equals(Boolean.TRUE)) {
             addressRepository.changeOldestAddressToDefault(user);
         }
 
-        usersAddressRepository.deleteByUserAndAddress(user, address);
-        addressRepository.delete(address);
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/config/SecurityConfig.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/config/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig {
         "/users/test",
         "/users/relogin",
         "/users/reissue",
+        "/users/email",
         "/oauth/signup",
         "/oauth",
         "/image",


### PR DESCRIPTION
### ⚡이슈 번호
resolve #43 

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 이메일 찾기 시 401 오류가 뜨는 현상이 있어 SecurityConfig에 "/users/email" 부분을 추가하였습니다.
- 배송지 추가 시 최초 추가일 경우(count == 0) 요청의 isDefault값에 관계없이 True값으로 설정하도록 변경했습니다.
- 배송지 수정 시 기본 배송지의 요청이 false로 올 경우 에러 문구를 전달하도록 변경하였습니다.
- 배송지 삭제 시, 현재는 생성일이 가장 오래된 기준으로만 판단하기 때문에 on절에 isDefault값이 false인 값들만 찾도록 변경했습니다.
---
### 📖 참고 사항
