### PR TITLE
feat | 상품의 문의 내역 조회 기능 구현

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/DutchiePayApplication.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/DutchiePayApplication.java
@@ -2,8 +2,12 @@ package dutchiepay.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
 @SpringBootApplication
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 public class DutchiePayApplication {
 
     public static void main(String[] args) {

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/controller/CommerceController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/controller/CommerceController.java
@@ -1,15 +1,20 @@
 package dutchiepay.backend.domain.commerce.controller;
 
 import dutchiepay.backend.domain.commerce.service.CommerceService;
-import dutchiepay.backend.domain.user.service.UserService;
+import dutchiepay.backend.domain.commerce.dto.BuyAskResponseDto;
+import dutchiepay.backend.entity.Ask;
 import dutchiepay.backend.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/commerce")
@@ -18,11 +23,20 @@ public class CommerceController {
 
     private final CommerceService commerceService;
 
-    @Operation(summary = "좋아요 기능(구현중)")
+    @Operation(summary = "상품 좋아요 기능(구현중)")
     @PatchMapping
     public ResponseEntity<Void> likes(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                 @RequestBody Map<String, Long> requestBody) {
         commerceService.likes(userDetails, requestBody.get("productId"));
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "상품 문의내역 조회")
+    @GetMapping("/asks")
+    public ResponseEntity<List<BuyAskResponseDto>> getBuyAsks(@RequestParam("productId") Long buyId,
+                                                              Pageable pageable) {
+        return ResponseEntity.ok(commerceService.getBuyAsks(buyId, pageable).getContent()
+                .stream().map(BuyAskResponseDto::toDto)
+                .collect(Collectors.toList()));
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/dto/BuyAskResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/dto/BuyAskResponseDto.java
@@ -1,0 +1,36 @@
+package dutchiepay.backend.domain.commerce.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dutchiepay.backend.entity.Ask;
+import dutchiepay.backend.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class BuyAskResponseDto {
+    private Long askId;
+    private Long userId;
+    private String nickname;
+    private String content;
+    private String answer;
+    private LocalDateTime createdAt;
+    private LocalDateTime answeredAt;
+    @JsonProperty("isSecret")
+    private boolean secret;
+
+    public static BuyAskResponseDto toDto(Ask ask) {
+        return BuyAskResponseDto.builder()
+                .askId(ask.getAskId())
+                .userId(ask.getUser().getUserId())
+                .nickname(ask.getUser().getNickname())
+                .content(ask.getContents())
+                .answer(ask.getAnswer())
+                .createdAt(ask.getCreatedAt())
+                .answeredAt(ask.getAnsweredAt())
+                .secret(ask.isSecret())
+                .build();
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/service/CommerceService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/service/CommerceService.java
@@ -1,19 +1,20 @@
 package dutchiepay.backend.domain.commerce.service;
 
+import dutchiepay.backend.domain.commerce.dto.BuyAskResponseDto;
 import dutchiepay.backend.domain.commerce.exception.CommerceErrorCode;
 import dutchiepay.backend.domain.commerce.exception.CommerceException;
 import dutchiepay.backend.domain.commerce.repository.BuyRepository;
+import dutchiepay.backend.domain.order.repository.AskRepository;
 import dutchiepay.backend.domain.order.repository.LikesRepository;
 import dutchiepay.backend.domain.order.repository.ProductRepository;
 import dutchiepay.backend.domain.order.service.OrdersService;
 import dutchiepay.backend.domain.user.service.UserService;
-import dutchiepay.backend.entity.Buy;
-import dutchiepay.backend.entity.Likes;
-import dutchiepay.backend.entity.Product;
-import dutchiepay.backend.entity.User;
+import dutchiepay.backend.entity.*;
 import dutchiepay.backend.global.security.UserDetailsImpl;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +27,7 @@ public class CommerceService {
 
     private final BuyRepository buyRepository;
     private final LikesRepository likesRepository;
+    private final AskRepository askRepository;
 
     /**
      * 상품 좋아요
@@ -42,5 +44,18 @@ public class CommerceService {
         } else {
             likesRepository.delete(likes);
         }
+    }
+
+    /**
+     * 상품의 문의 내역 목록을 조회
+     * Pagination 구현
+     * @param buyId 조회할 상품의 게시글 Id
+     * @param pageable pageable 객체
+     * @return BuyAskResponseDto 문의 내역 dto
+     */
+    public Page<Ask> getBuyAsks(Long buyId, Pageable pageable) {
+
+        return askRepository.findByBuyAndDeletedAtIsNull(buyRepository.findById(buyId)
+                .orElseThrow(() -> new CommerceException(CommerceErrorCode.CANNOT_FOUND_PRODUCT)), pageable);
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/repository/AskRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/repository/AskRepository.java
@@ -1,7 +1,10 @@
 package dutchiepay.backend.domain.order.repository;
 
 import dutchiepay.backend.entity.Ask;
+import dutchiepay.backend.entity.Buy;
 import dutchiepay.backend.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +18,6 @@ public interface AskRepository extends JpaRepository<Ask, Long> {
     void softDelete(Ask ask);
 
     List<Ask> findAllByUser(User user);
+
+    Page<Ask> findByBuyAndDeletedAtIsNull(Buy buy, Pageable pageable);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/config/SecurityConfig.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/config/SecurityConfig.java
@@ -58,9 +58,9 @@ public class SecurityConfig {
         "/users/reissue",
         "/users/email",
         "/oauth/signup",
-        "/oauth",
         "/image",
-        "/health"
+        "/health",
+        "/commerce/asks"
     };
 
     private final String[] readOnlyUrl = {


### PR DESCRIPTION
### ⚡이슈 번호
resolve #54 

---
### ✅ PR 종류
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- BuyAskResponseDto 생성
- 상품의 문의 내역 중 deletedAt이 null인 값들만 가져옴
- json 반환 시 is 접두어가 붙으면 인식이 안 되어서 `@JsonProperty` 어노테이션 추가
- Pageable 객체 사용 시 Page 인터페이스의 직렬화 문제로 인한 Warning 해결을 위해 main class에 `@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)` 어노테이션 추가
- Pageable 객체를 사용하여 반환 시 불필요한 "content", "page" 정보가 추가되어 Page<Asks> 객체를 각각 BuyAskResponseDto로 변환하여 List로 생성
- 비회원도 접근 가능한 페이지라서 SecurityConfig permitAllUrl에 "/commerce/asks" 추가

---
### 📖 참고 사항
