### PR TITLE
55/회원 탈퇴 시 find 조건 추가, oauth 성공 url 수정

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/controller/UserController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/controller/UserController.java
@@ -114,9 +114,9 @@ public class UserController {
 
     @Operation(summary = "회원 탈퇴(추가 수정 필요)", description = "개인정보 삭제 범위, 재가입 불가 구분용 정보 필요")
     @DeleteMapping
-    public ResponseEntity<?> deleteUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         userService.deleteUser(userDetails);
-        return ResponseEntity.ok().body(null);
+        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "자동로그인(구현 완료)")

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
@@ -213,7 +213,7 @@ public class UserService {
 
     @Transactional
     public void deleteUser(UserDetailsImpl userDetails) {
-        userRepository.findByEmail(userDetails.getEmail())
+        userRepository.findByEmailAndOauthProviderIsNull(userDetails.getEmail())
             .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_EMAIL_NOT_FOUND)).delete();
     }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/handler/CustomOAuth2SuccessHandler.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/handler/CustomOAuth2SuccessHandler.java
@@ -84,7 +84,7 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
                 "</head>\n" +
                 "<body>\n" +
                 "    <script>\n" +
-                "    window.opener.postMessage({type: \"OAUTH_LOGIN\", encrypted: \"" + encryptedData + "\"}, \"https://dutchie-pay.site\");\n" +
+                "    window.opener.postMessage({type: \"OAUTH_LOGIN\", encrypted: \"" + encryptedData + "\"}, \"https://www.dutchie-pay.site\");\n" +
                 "    window.close();\n" +
                 "    </script>\n" +
                 "</body>\n" +


### PR DESCRIPTION
### ⚡이슈 번호
resolve #55 

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 회원 탈퇴 시 findByEmail로만 회원을 찾아 중복 값이 발생하는 오류 -> findByEmailAndOauthProviderIsNull로 이메일 회원만 찾도록 변경
- 소셜 로그인 성공 후 postMessage에 origin url에 www가 없어 오류 발생 -> www. 추가
---
### 📖 참고 사항
