### PR TITLE
fix | 소셜 회원 탈퇴 delete 로직 분리

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/oauth/controller/OauthController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/oauth/controller/OauthController.java
@@ -30,6 +30,7 @@ public class OauthController {
         } else {
             userService.unlinkNaver(userDetails);
         }
+        userService.deleteOauthUser(userDetails);
         return "redirect:/";
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
@@ -174,9 +174,6 @@ public class UserService {
             entity,                          // HttpEntity (본문 없음, 헤더만 있음)
             String.class                     // 응답 타입
         );
-
-        userRepository.findByOauthProviderAndEmail(userDetails.getOAuthProvider(), userDetails.getEmail())
-                .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_EMAIL_NOT_FOUND)).delete();
     }
 
     @Transactional
@@ -206,7 +203,10 @@ public class UserService {
             null,                          // HttpEntity
             String.class                     // 응답 타입
         );
+    }
 
+    @Transactional
+    public void deleteOauthUser(UserDetailsImpl userDetails) {
         userRepository.findByOauthProviderAndEmail(userDetails.getOAuthProvider(), userDetails.getEmail())
                 .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_EMAIL_NOT_FOUND)).delete();
     }


### PR DESCRIPTION
### ⚡이슈 번호
resolve #62 

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 소셜 회원 탈퇴 후 동일 이메일로 로그인 시도 시, 기존 unlink 메서드에 delete하는 로직이 같이 있어 CustomOAuth2UserService에서 unlink를 호출하면서 deletedAt 필드가 업데이트 되는 현상 발생
     -> deleteOauthUser 메서드를 생성, Controller로 요청이 들어왔을 때(정상적으로 탈퇴하는 경우)만 deletedAt을 수정하도록 변경 
---
### 📖 참고 사항
