### PR TITLE
엔티티 추가 / 상품 추가 API 변경 / 유저 기능 오류 수정

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/BuyCategoryEnum.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/BuyCategoryEnum.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public enum BuyCategory {
+public enum BuyCategoryEnum {
     잡화("잡화", "0"),
     가구("인테리어/가구", "1"),
     보안("보안용품", "2"),
@@ -25,23 +25,23 @@ public enum BuyCategory {
     private final String category;
     private final String code;
 
-    public static BuyCategory ofCategory(String dbData) {
-        return Arrays.stream(BuyCategory.values())
+    public static BuyCategoryEnum ofCategory(String dbData) {
+        return Arrays.stream(BuyCategoryEnum.values())
                 .filter(v -> v.getCode().equals(dbData))
                 .findAny()
                 .orElseThrow(() -> new ProfileErrorException(ProfileErrorCode.INVALID_CATEGORY));
     }
 
-    public static BuyCategory fromCategoryName(String categoryName) {
-        return Arrays.stream(BuyCategory.values())
+    public static BuyCategoryEnum fromCategoryName(String categoryName) {
+        return Arrays.stream(BuyCategoryEnum.values())
                 .filter(v -> v.getCategory().equals(categoryName))
                 .findAny()
                 .orElseThrow(() -> new IllegalArgumentException(String.format("일치하는 카테고리명이 없습니다 %s", categoryName)));
     }
 
     public static boolean isExist(String categoryName) {
-        for (BuyCategory buyCategory : BuyCategory.values()) {
-            if (buyCategory.getCategory().equals(categoryName)) {
+        for (BuyCategoryEnum buyCategoryEnum : BuyCategoryEnum.values()) {
+            if (buyCategoryEnum.getCategory().equals(categoryName)) {
                 return true;
             }
         }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/controller/CommerceController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/controller/CommerceController.java
@@ -60,7 +60,7 @@ public class CommerceController {
 
     @Operation(summary = "상품 문의내역 조회(구현중)")
     @GetMapping("/asks")
-    public ResponseEntity<List<BuyAskResponseDto>> getBuyAsks(@RequestParam("productId") Long buyId,
+    public ResponseEntity<List<BuyAskResponseDto>> getBuyAsks(@RequestParam("buyId") Long buyId,
                                                               Pageable pageable) {
         return ResponseEntity.ok(commerceService.getBuyAsks(buyId, pageable).getContent()
                 .stream().map(BuyAskResponseDto::toDto)
@@ -69,7 +69,7 @@ public class CommerceController {
 
     @Operation(summary = "결제 정보 불러오기(구현중)")
     @GetMapping("/delivery")
-    public ResponseEntity<PaymentInfoResponseDto> getPaymentInfo(@RequestParam("buypostid") Long buyId) {
+    public ResponseEntity<PaymentInfoResponseDto> getPaymentInfo(@RequestParam("buyId") Long buyId) {
         return ResponseEntity.ok(commerceService.getPaymentInfo(buyId));
     }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/dto/AddEntityDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/dto/AddEntityDto.java
@@ -1,6 +1,6 @@
 package dutchiepay.backend.domain.commerce.dto;
 
-import dutchiepay.backend.domain.commerce.BuyCategory;
+import dutchiepay.backend.domain.commerce.BuyCategoryEnum;
 import lombok.Getter;
 
 import java.time.LocalDate;
@@ -13,7 +13,7 @@ public class AddEntityDto {
     private int originalPrice;
     private int salePrice;
     private int discountPercent;
-    private BuyCategory category;
+    private BuyCategoryEnum category;
     private int skeleton;
     private LocalDate deadline;
     private Long storeId;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/dto/AddEntityDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/dto/AddEntityDto.java
@@ -13,7 +13,7 @@ public class AddEntityDto {
     private int originalPrice;
     private int salePrice;
     private int discountPercent;
-    private BuyCategoryEnum category;
+    private String category;
     private int skeleton;
     private LocalDate deadline;
     private Long storeId;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/dto/PaymentInfoResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/dto/PaymentInfoResponseDto.java
@@ -18,10 +18,10 @@ public class PaymentInfoResponseDto {
 
     public static PaymentInfoResponseDto toDto(Buy buy) {
         return PaymentInfoResponseDto.builder()
-                .productName(buy.getProductId().getProductName())
-                .productImg(buy.getProductId().getProductImg())
-                .originalPrice(buy.getProductId().getOriginalPrice())
-                .salePrice(buy.getProductId().getSalePrice())
+                .productName(buy.getProduct().getProductName())
+                .productImg(buy.getProduct().getProductImg())
+                .originalPrice(buy.getProduct().getOriginalPrice())
+                .salePrice(buy.getProduct().getSalePrice())
                 .expireDate(buy.getDeadline())
                 .build();
     }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/BuyCategoryRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/BuyCategoryRepository.java
@@ -1,0 +1,7 @@
+package dutchiepay.backend.domain.commerce.repository;
+
+import dutchiepay.backend.entity.BuyCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BuyCategoryRepository extends JpaRepository<BuyCategory, Long> {
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/CategoryRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package dutchiepay.backend.domain.commerce.repository;
+
+import dutchiepay.backend.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
@@ -37,6 +37,8 @@ public class QBuyRepositoryImpl implements QBuyRepository{
     QLikes likes = QLikes.likes;
     QAsk ask = QAsk.ask;
     QScore score = QScore.score;
+    QBuyCategory buyCategory = QBuyCategory.buyCategory;
+    QCategory category = QCategory.category;
 
     @Override
     public GetBuyResponseDto getBuyPageByBuyId(Long userId, Long buyId) {
@@ -121,11 +123,17 @@ public class QBuyRepositoryImpl implements QBuyRepository{
     }
 
     @Override
-    public GetBuyListResponseDto getBuyList(User user, String filter, String category, int end, Long cursor, int limit) {
+    public GetBuyListResponseDto getBuyList(User user, String filter, String categoryName, int end, Long cursor, int limit) {
         BooleanExpression conditions = buy.buyId.gt(cursor);
 
-        if (category != null && !category.isEmpty()) {
-            conditions = conditions.and(buy.category.eq(BuyCategoryEnum.valueOf(category)));
+        if (categoryName != null && !categoryName.isEmpty()) {
+            conditions = conditions.and(
+                    JPAExpressions
+                            .select(buyCategory.buy)
+                            .from(buyCategory)
+                            .where(buyCategory.category.name.eq(categoryName))
+                            .contains(buy)
+            );
         }
 
         if (end == 0) {
@@ -161,6 +169,8 @@ public class QBuyRepositoryImpl implements QBuyRepository{
                         likes.count().gt(0L).as("isLiked"))
                 .from(buy)
                 .join(buy.product, product)
+                .leftJoin(buyCategory).on(buyCategory.buy.eq(buy))
+                .leftJoin(category).on(buyCategory.category.eq(category))
                 .leftJoin(likes).on(likes.buy.eq(buy).and(likes.user.eq(user)))
                 .where(conditions)
                 .groupBy(buy.buyId, product.productName, product.productImg, product.originalPrice,

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
@@ -5,7 +5,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import dutchiepay.backend.domain.commerce.BuyCategory;
+import dutchiepay.backend.domain.commerce.BuyCategoryEnum;
 import dutchiepay.backend.domain.commerce.dto.GetBuyListResponseDto;
 import dutchiepay.backend.domain.commerce.dto.GetBuyResponseDto;
 import dutchiepay.backend.domain.commerce.dto.GetProductReviewResponseDto;
@@ -125,7 +125,7 @@ public class QBuyRepositoryImpl implements QBuyRepository{
         BooleanExpression conditions = buy.buyId.gt(cursor);
 
         if (category != null && !category.isEmpty()) {
-            conditions = conditions.and(buy.category.eq(BuyCategory.valueOf(category)));
+            conditions = conditions.and(buy.category.eq(BuyCategoryEnum.valueOf(category)));
         }
 
         if (end == 0) {

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/service/CommerceService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/service/CommerceService.java
@@ -7,7 +7,9 @@ import dutchiepay.backend.domain.commerce.dto.AddEntityDto;
 import dutchiepay.backend.domain.commerce.dto.PaymentInfoResponseDto;
 import dutchiepay.backend.domain.commerce.exception.CommerceErrorCode;
 import dutchiepay.backend.domain.commerce.exception.CommerceException;
+import dutchiepay.backend.domain.commerce.repository.BuyCategoryRepository;
 import dutchiepay.backend.domain.commerce.repository.BuyRepository;
+import dutchiepay.backend.domain.commerce.repository.CategoryRepository;
 import dutchiepay.backend.domain.commerce.repository.StoreRepository;
 import dutchiepay.backend.domain.order.repository.AskRepository;
 import dutchiepay.backend.domain.order.repository.LikesRepository;
@@ -33,6 +35,8 @@ public class CommerceService {
     private final AskRepository askRepository;
     private final ProductRepository productRepository;
     private final StoreRepository storeRepository;
+    private final CategoryRepository categoryRepository;
+    private final BuyCategoryRepository buyCategoryRepository;
 
     /**
      * 상품 좋아요
@@ -108,12 +112,25 @@ public class CommerceService {
                 .discountPercent(addEntityDto.getDiscountPercent())
                 .productImg(addEntityDto.getProductImg()).build());
 
-        buyRepository.save(Buy.builder()
+        Buy buy = Buy.builder()
                 .product(product)
                 .title(addEntityDto.getProductName())
                 .deadline(addEntityDto.getDeadline())
                 .skeleton(addEntityDto.getSkeleton())
                 .nowCount(0)
-                .category(addEntityDto.getCategory()).build());
+                .build();
+
+        buyRepository.save(buy);
+
+        Category category = Category.builder()
+                .name(addEntityDto.getCategory())
+                .build();
+
+        categoryRepository.save(category);
+
+        buyCategoryRepository.save(BuyCategory.builder()
+                .buy(buy)
+                .category(category)
+                .build());
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/controller/ProfileController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/controller/ProfileController.java
@@ -106,7 +106,7 @@ public class ProfileController {
     @Operation(summary = "프로필 이미지 변경 (구현 완료)")
     @PatchMapping("/image")
     public ResponseEntity<?> changeProfileImage(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                @Valid @RequestBody ChangeProfileImgRequestDto request) {
+                                                @RequestBody ChangeProfileImgRequestDto request) {
         profileService.changeProfileImage(userDetails.getUser(), request.getProfileImg());
         return ResponseEntity.ok().build();
     }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/ChangeProfileImgRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/ChangeProfileImgRequestDto.java
@@ -8,6 +8,5 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChangeProfileImgRequestDto {
-    @NotBlank(message = "프로필 이미지를 입력해주세요.")
     private String profileImg;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/GetMyLikesResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/GetMyLikesResponseDto.java
@@ -1,16 +1,14 @@
 package dutchiepay.backend.domain.profile.dto;
 
-import dutchiepay.backend.domain.commerce.BuyCategory;
+import dutchiepay.backend.domain.commerce.BuyCategoryEnum;
 import lombok.*;
-
-import java.util.List;
 
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GetMyLikesResponseDto {
-    private BuyCategory category;
+    private BuyCategoryEnum category;
     private String title;
     private Integer originalPrice;
     private Integer salePrice;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/GetMyLikesResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/GetMyLikesResponseDto.java
@@ -1,6 +1,5 @@
 package dutchiepay.backend.domain.profile.dto;
 
-import dutchiepay.backend.domain.commerce.BuyCategoryEnum;
 import lombok.*;
 
 @Getter
@@ -8,7 +7,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GetMyLikesResponseDto {
-    private BuyCategoryEnum category;
+    private String category;
     private String title;
     private Integer originalPrice;
     private Integer salePrice;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
@@ -7,7 +7,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import dutchiepay.backend.domain.commerce.BuyCategory;
+import dutchiepay.backend.domain.commerce.BuyCategoryEnum;
 import dutchiepay.backend.domain.profile.dto.GetMyLikesResponseDto;
 import dutchiepay.backend.domain.profile.dto.MyGoodsResponseDto;
 import dutchiepay.backend.domain.profile.dto.MyPostsResponseDto;
@@ -254,6 +254,6 @@ public class QProfileRepositoryImpl implements QProfileRepository {
     }
 
     private BooleanExpression categoryEq(String category) {
-        return category != null ? buy.category.eq(BuyCategory.fromCategoryName(category)) : null;
+        return category != null ? buy.category.eq(BuyCategoryEnum.fromCategoryName(category)) : null;
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
@@ -1,6 +1,6 @@
 package dutchiepay.backend.domain.profile.service;
 
-import dutchiepay.backend.domain.commerce.BuyCategory;
+import dutchiepay.backend.domain.commerce.BuyCategoryEnum;
 import dutchiepay.backend.domain.order.repository.*;
 import dutchiepay.backend.domain.profile.dto.*;
 import dutchiepay.backend.domain.profile.exception.ProfileErrorCode;
@@ -47,7 +47,7 @@ public class ProfileService {
 
 
     public List<GetMyLikesResponseDto> getMyLike(User user, String category) {
-        if (!BuyCategory.isExist(category)) {
+        if (!BuyCategoryEnum.isExist(category)) {
             throw new ProfileErrorException(ProfileErrorCode.INVALID_CATEGORY);
         }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/NonUserChangePasswordRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/NonUserChangePasswordRequestDto.java
@@ -15,6 +15,6 @@ public class NonUserChangePasswordRequestDto {
     private String email;
 
     @NotBlank(message = "비밀번호를 입력해주세요.")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$", message = "영문, 숫자, 특수문자를 모두 포함하여 8글자 이상으로 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[\\W_])[A-Za-z\\d\\W_]{8,}$", message = "영문, 숫자, 특수문자를 모두 포함하여 8글자 이상으로 입력해주세요.")
     private String password;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserChangePasswordRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserChangePasswordRequestDto.java
@@ -10,9 +10,9 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserChangePasswordRequestDto {
     @NotBlank(message = "기존 비밀번호를 입력해주세요.")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$", message = "영문, 숫자, 특수문자를 모두 포함하여 8글자 이상으로 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[\\W_])[A-Za-z\\d\\W_]{8,}$", message = "영문, 숫자, 특수문자를 모두 포함하여 8글자 이상으로 입력해주세요.")
     private String password;
     @NotBlank(message = "새로운 비밀번호를 입력해주세요.")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$", message = "영문, 숫자, 특수문자를 모두 포함하여 8글자 이상으로 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[\\W_])[A-Za-z\\d\\W_]{8,}$", message = "영문, 숫자, 특수문자를 모두 포함하여 8글자 이상으로 입력해주세요.")
     private String newPassword;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserLoginRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserLoginRequestDto.java
@@ -20,7 +20,7 @@ public class UserLoginRequestDto {
     private String email;
 
     @NotBlank(message = "비밀번호를 입력해주세요.")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$", message = "영문, 숫자, 특수문자를 모두 포함하여 8글자 이상으로 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[\\W_])[A-Za-z\\d\\W_]{8,}$", message = "영문, 숫자, 특수문자를 모두 포함하여 8글자 이상으로 입력해주세요.")
     private String password;
 
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserSignupRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/dto/UserSignupRequestDto.java
@@ -20,7 +20,7 @@ public class UserSignupRequestDto {
     private String email;
 
     @NotBlank(message = "비밀번호를 입력해주세요.")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$", message = "영문, 숫자, 특수문자를 모두 포함하여 8글자 이상으로 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[\\W_])[A-Za-z\\d\\W_]{8,}$", message = "영문, 숫자, 특수문자를 모두 포함하여 8글자 이상으로 입력해주세요.")
     private String password;
 
     @NotBlank(message = "전화번호를 입력해주세요.")

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Buy.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Buy.java
@@ -1,8 +1,6 @@
 package dutchiepay.backend.entity;
 
-import dutchiepay.backend.domain.commerce.BuyCategory;
 import dutchiepay.backend.global.config.Auditing;
-import dutchiepay.backend.global.converter.BuyCategoryConverter;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -39,9 +37,4 @@ public class Buy extends Auditing {
     // 현재 수량
     @Column(nullable = false)
     private int nowCount;
-
-    // 카테고리
-    @Convert(converter = BuyCategoryConverter.class)
-    @Column(nullable = false)
-    private BuyCategory category;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/BuyCategory.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/BuyCategory.java
@@ -1,0 +1,25 @@
+package dutchiepay.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Table(name = "Buy_Category")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BuyCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long buyCategoryId;
+
+    @ManyToOne
+    @JoinColumn(name = "buy_id")
+    private Buy buy;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    private Category category;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Category.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Category.java
@@ -16,5 +16,6 @@ public class Category extends Auditing {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long categoryId;
 
+    @Column(nullable = false)
     private String name;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Category.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Category.java
@@ -1,0 +1,20 @@
+package dutchiepay.backend.entity;
+
+import dutchiepay.backend.global.config.Auditing;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Table(name = "Category")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category extends Auditing {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long categoryId;
+
+    private String name;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/converter/BuyCategoryConverter.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/converter/BuyCategoryConverter.java
@@ -1,18 +1,18 @@
 package dutchiepay.backend.global.converter;
 
-import dutchiepay.backend.domain.commerce.BuyCategory;
+import dutchiepay.backend.domain.commerce.BuyCategoryEnum;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 
 @Converter
-public class BuyCategoryConverter implements AttributeConverter<BuyCategory, String> {
+public class BuyCategoryConverter implements AttributeConverter<BuyCategoryEnum, String> {
     @Override
-    public String convertToDatabaseColumn(BuyCategory buyCategory) {
-        return buyCategory.getCode();
+    public String convertToDatabaseColumn(BuyCategoryEnum buyCategoryEnum) {
+        return buyCategoryEnum.getCode();
     }
 
     @Override
-    public BuyCategory convertToEntityAttribute(String dbData) {
-        return BuyCategory.ofCategory(dbData);
+    public BuyCategoryEnum convertToEntityAttribute(String dbData) {
+        return BuyCategoryEnum.ofCategory(dbData);
     }
 }

--- a/DutchiePay/src/test/java/dutchiepay/backend/ProfileRepositoryTest.java
+++ b/DutchiePay/src/test/java/dutchiepay/backend/ProfileRepositoryTest.java
@@ -109,7 +109,7 @@ class ProfileRepositoryTest {
 
         // 상품
         Product product1 = Product.builder()
-                .storeId(store)
+                .store(store)
                 .productName("테스트 상품1")
                 .detailImg("테스트 상세 이미지1")
                 .originalPrice(10000)
@@ -119,7 +119,7 @@ class ProfileRepositoryTest {
                 .build();
 
         Product product2 = Product.builder()
-                .storeId(store)
+                .store(store)
                 .productName("테스트 상품2")
                 .detailImg("테스트 상세 이미지2")
                 .originalPrice(10000)
@@ -132,21 +132,19 @@ class ProfileRepositoryTest {
 
         // 공구게시글
         Buy buy1 = Buy.builder()
-                .productId(product1)
+                .product(product1)
                 .title("테스트 공구 게시글1")
                 .deadline(LocalDate.now())
                 .skeleton(10)
                 .nowCount(100)
-                .category(BuyCategoryEnum.가전)
                 .build();
 
         Buy buy2 = Buy.builder()
-                .productId(product2)
+                .product(product2)
                 .title("테스트 공구 게시글2")
                 .deadline(LocalDate.now())
                 .skeleton(10)
                 .nowCount(100)
-                .category(BuyCategoryEnum.가전)
                 .build();
         buyRepository.save(buy1);
         buyRepository.save(buy2);
@@ -244,7 +242,7 @@ class ProfileRepositoryTest {
 
         // 상품
         Product product = Product.builder()
-                .storeId(store)
+                .store(store)
                 .productName("테스트 상품")
                 .detailImg("테스트 상세 이미지")
                 .originalPrice(10000)
@@ -256,12 +254,11 @@ class ProfileRepositoryTest {
 
         // 공구게시글
         Buy buy = Buy.builder()
-                .productId(product)
+                .product(product)
                 .title("테스트 공구 게시글1")
                 .deadline(LocalDate.now())
                 .skeleton(10)
                 .nowCount(100)
-                .category(BuyCategoryEnum.가전)
                 .build();
         buyRepository.save(buy);
 
@@ -326,7 +323,7 @@ class ProfileRepositoryTest {
 
         // 상품
         Product product1 = Product.builder()
-                .storeId(store)
+                .store(store)
                 .productName("테스트 상품")
                 .detailImg("테스트 상세 이미지")
                 .originalPrice(10000)
@@ -336,7 +333,7 @@ class ProfileRepositoryTest {
                 .build();
 
         Product product2 = Product.builder()
-                .storeId(store)
+                .store(store)
                 .productName("테스트 상품2")
                 .detailImg("테스트 상세 이미지2")
                 .originalPrice(5000)
@@ -349,21 +346,19 @@ class ProfileRepositoryTest {
 
         // 공구 게시글
         Buy buy1 = Buy.builder()
-                .productId(product1)
+                .product(product1)
                 .title("테스트 공구 게시글1")
                 .deadline(LocalDate.now())
                 .skeleton(10)
                 .nowCount(100)
-                .category(BuyCategoryEnum.가전)
                 .build();
 
         Buy buy2 = Buy.builder()
-                .productId(product2)
+                .product(product2)
                 .title("테스트 공구 게시글1")
                 .deadline(LocalDate.now())
                 .skeleton(10)
                 .nowCount(100)
-                .category(BuyCategoryEnum.가전)
                 .build();
         buyRepository.save(buy1);
         buyRepository.save(buy2);
@@ -461,7 +456,7 @@ class ProfileRepositoryTest {
 
         // 마트/배달 게시글
         Share sharePost1 = Share.builder()
-                .userId(user)
+                .user(user)
                 .title("테스트 마트/배달 게시글1")
                 .contents("테스트 마트/배달 게시글 내용1")
                 .category("배달")
@@ -529,14 +524,14 @@ class ProfileRepositoryTest {
 
         // 댓글
         Comment comment1 = Comment.builder()
-                .freeId(freePost1)
-                .userId(user)
+                .free(freePost1)
+                .user(user)
                 .contents("테스트 댓글 내용1")
                 .build();
 
         Comment comment2 = Comment.builder()
-                .freeId(freePost2)
-                .userId(user)
+                .free(freePost2)
+                .user(user)
                 .contents("테스트 댓글 내용2")
                 .build();
         commentRepository.save(comment1);

--- a/DutchiePay/src/test/java/dutchiepay/backend/ProfileRepositoryTest.java
+++ b/DutchiePay/src/test/java/dutchiepay/backend/ProfileRepositoryTest.java
@@ -1,6 +1,6 @@
 package dutchiepay.backend;
 
-import dutchiepay.backend.domain.commerce.BuyCategory;
+import dutchiepay.backend.domain.commerce.BuyCategoryEnum;
 import dutchiepay.backend.domain.commerce.repository.*;
 import dutchiepay.backend.domain.coupon.repository.CouponRepository;
 import dutchiepay.backend.domain.coupon.repository.UsersCouponRepository;
@@ -137,7 +137,7 @@ class ProfileRepositoryTest {
                 .deadline(LocalDate.now())
                 .skeleton(10)
                 .nowCount(100)
-                .category(BuyCategory.가전)
+                .category(BuyCategoryEnum.가전)
                 .build();
 
         Buy buy2 = Buy.builder()
@@ -146,7 +146,7 @@ class ProfileRepositoryTest {
                 .deadline(LocalDate.now())
                 .skeleton(10)
                 .nowCount(100)
-                .category(BuyCategory.가전)
+                .category(BuyCategoryEnum.가전)
                 .build();
         buyRepository.save(buy1);
         buyRepository.save(buy2);
@@ -261,7 +261,7 @@ class ProfileRepositoryTest {
                 .deadline(LocalDate.now())
                 .skeleton(10)
                 .nowCount(100)
-                .category(BuyCategory.가전)
+                .category(BuyCategoryEnum.가전)
                 .build();
         buyRepository.save(buy);
 
@@ -354,7 +354,7 @@ class ProfileRepositoryTest {
                 .deadline(LocalDate.now())
                 .skeleton(10)
                 .nowCount(100)
-                .category(BuyCategory.가전)
+                .category(BuyCategoryEnum.가전)
                 .build();
 
         Buy buy2 = Buy.builder()
@@ -363,7 +363,7 @@ class ProfileRepositoryTest {
                 .deadline(LocalDate.now())
                 .skeleton(10)
                 .nowCount(100)
-                .category(BuyCategory.가전)
+                .category(BuyCategoryEnum.가전)
                 .build();
         buyRepository.save(buy1);
         buyRepository.save(buy2);


### PR DESCRIPTION
### ⚡이슈 번호
resolve #66 

---
### ✅ PR 종류
- [x] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 공구게시글 1개 당 2개의 카테고리를 가질 수 있기 때문에 Category, BuyCategory 엔티티를 추가하여 다대다 관계 설정
- 기존 BuyCategory enum 클래스 및 converter 사용하지 않는 것으로 변경
- 비밀번호 입력 시 모든 특수문자를 받을 수 있도록 설정
- 기본 프로필 이미지 변경 요청 시 Null값 허용하도록 변경
- 공동구매 컨트롤러에서 request parameter와 사용 parameter 간 매칭되지 않는 문제 공통화
- 엔티티 추가로 인한 Category,BuyCategory repository 생성
- 상품 추가 api에서 category 설정할 수 있도록 변경
---
### 📖 참고 사항
