### PR TITLE
73/fix login fail

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/exception/UserErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/exception/UserErrorCode.java
@@ -18,11 +18,6 @@ public enum UserErrorCode implements StatusCode {
     USER_PHONE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용중인 전화번호입니다."),
     USER_NICKNAME_MISSING(HttpStatus.BAD_REQUEST, "닉네임을 입력해 주세요."),
     USER_EMAIL_MISSING(HttpStatus.BAD_REQUEST, "이메일을 입력해 주세요."),
-    USER_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일입니다."),
-    USER_EMAIL_SUSPENDED(HttpStatus.BAD_REQUEST, "정지된 회원의 이메일은 사용할 수 없습니다."),
-    USER_EMAIL_TERMINATED(HttpStatus.BAD_REQUEST, "탈퇴한 회원의 이메일입니다. 탈퇴 후 재가입 할 수 없습니다."),
-    USER_INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 올바르지 않습니다."),
-    DELETED_USER(HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다."),
     USER_SAME_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 동일합니다."),
     SAME_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 새로운 비밀번호가 같습니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호가 올바르지 않습니다."),
@@ -36,8 +31,7 @@ public enum UserErrorCode implements StatusCode {
     /**
      * 403 FORBIDDEN
      */
-    USER_SUSPENDED(HttpStatus.FORBIDDEN, "정지된 회원입니다."),
-    USER_TERMINATED(HttpStatus.FORBIDDEN, "탈퇴한 회원입니다.");
+    USER_SUSPENDED(HttpStatus.FORBIDDEN, "정지된 회원입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/repository/UserRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/repository/UserRepository.java
@@ -10,7 +10,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
-    Optional<User> findByOauthProviderAndEmail(String oauthId, String email);
+    Optional<User> findByOauthProviderAndEmail(String oauthProvider, String email);
 
     Optional<User> findByNickname(String username);
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/user/service/UserService.java
@@ -90,7 +90,7 @@ public class UserService {
             if (now.getState() == 1) {
                 throw new UserErrorException(UserErrorCode.USER_SUSPENDED);
             } else if (now.getState() == 2) {
-                throw new UserErrorException(UserErrorCode.USER_TERMINATED);
+                throw new UserErrorException(UserErrorCode.USER_NOT_FOUND);
             } else {
                 throw new UserErrorException(UserErrorCode.USER_EMAIL_ALREADY_EXISTS);
             }
@@ -109,7 +109,7 @@ public class UserService {
         if (user.getState() == 1) {
             throw new UserErrorException(UserErrorCode.USER_SUSPENDED);
         } else if (user.getState() == 2) {
-            throw new UserErrorException(UserErrorCode.USER_TERMINATED);
+            throw new UserErrorException(UserErrorCode.USER_NOT_FOUND);
         }
 
         return FindEmailResponseDto.of(userUtilService.maskEmail(user.getEmail()));
@@ -208,13 +208,13 @@ public class UserService {
     @Transactional
     public void deleteOauthUser(UserDetailsImpl userDetails) {
         userRepository.findByOauthProviderAndEmail(userDetails.getOAuthProvider(), userDetails.getEmail())
-                .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_EMAIL_NOT_FOUND)).delete();
+                .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_NOT_FOUND)).delete();
     }
 
     @Transactional
     public void deleteUser(UserDetailsImpl userDetails) {
         userRepository.findByEmailAndOauthProviderIsNull(userDetails.getEmail())
-            .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_EMAIL_NOT_FOUND)).delete();
+            .orElseThrow(() -> new UserErrorException(UserErrorCode.USER_NOT_FOUND)).delete();
     }
 
     public UserLoginResponseDto userInfo(UserDetailsImpl userDetails) {

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/service/CustomOAuth2UserService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/oauth/service/CustomOAuth2UserService.java
@@ -52,7 +52,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
             else {
                 userService.unlinkNaver(new UserDetailsImpl(user, attributes));
             }
-            throw new UserErrorException(UserErrorCode.DELETED_USER);
+            throw new UserErrorException(UserErrorCode.USER_NOT_FOUND);
         }
 
         if (!user.getOauthProvider().equals(oAuthAttribute.getOauthProvider())) {


### PR DESCRIPTION
### ⚡이슈 번호
resolve #73 

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 로그인 시 이메일/비밀번호 불일치, 탈퇴한 회원의 경우 "해당하는 유저가 없습니다." 메시지로 통일
- 사용하지 않는 UserErrorCode 삭제
- USER_EMAIL_NOT_FOUND, USER_INVALID_PASSWORD, DELETE_USER, USER_TERMINATED 사용처 -> USER_NOT_FOUND로 변경
- 로그인 실패 시 error message와 함께 반환하도록 수정
- UserRepository - findByOauthProviderAndEmail에서 파라미터 값이 (String oauthId, )로 되어있던 것을 (String oauthProvider, )로 변경
---
### 📖 참고 사항
