### PR TITLE
배송지 리스트 조회 api 기능 수정

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/controller/CommerceController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/controller/CommerceController.java
@@ -24,12 +24,12 @@ public class CommerceController {
     private final CommerceService commerceService;
 
     @Operation(summary = "공동구매 리스트 조회(구현중)")
-    @GetMapping(value = "/list", params = {"filter", "category", "end", "cursor", "limit"})
+    @GetMapping(value = "/list")
     public ResponseEntity<?> getBuyList(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                         @RequestParam("filter") String filter,
-                                        @RequestParam("category") String category,
+                                        @RequestParam(value = "category", required = false) String category,
                                         @RequestParam("end") int end,
-                                        @RequestParam("cursor") Long cursor,
+                                        @RequestParam(value = "cursor", required = false) Long cursor,
                                         @RequestParam("limit") int limit) {
         return ResponseEntity.ok().body(commerceService.getBuyList(userDetails.getUser(), filter, category, end, cursor, limit));
     }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/exception/CommerceErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/exception/CommerceErrorCode.java
@@ -13,6 +13,7 @@ public enum CommerceErrorCode implements StatusCode {
      * 400 Bad Request
      */
     AFTER_DUE_DATE(HttpStatus.BAD_REQUEST, "마감된 상품입니다."),
+    INVALID_FILTER(HttpStatus.BAD_REQUEST, "유효하지 않은 필터입니다."),
 
     /**
      * 404 Not Found

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
@@ -5,10 +5,11 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import dutchiepay.backend.domain.commerce.BuyCategoryEnum;
 import dutchiepay.backend.domain.commerce.dto.GetBuyListResponseDto;
 import dutchiepay.backend.domain.commerce.dto.GetBuyResponseDto;
 import dutchiepay.backend.domain.commerce.dto.GetProductReviewResponseDto;
+import dutchiepay.backend.domain.commerce.exception.CommerceErrorCode;
+import dutchiepay.backend.domain.commerce.exception.CommerceException;
 import dutchiepay.backend.entity.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -124,6 +125,10 @@ public class QBuyRepositoryImpl implements QBuyRepository{
 
     @Override
     public GetBuyListResponseDto getBuyList(User user, String filter, String categoryName, int end, Long cursor, int limit) {
+        if (cursor == null) {
+            cursor = 0L;
+        }
+
         BooleanExpression conditions = buy.buyId.gt(cursor);
 
         if (categoryName != null && !categoryName.isEmpty()) {
@@ -151,9 +156,11 @@ public class QBuyRepositoryImpl implements QBuyRepository{
             case "discount":
                 orderBy = product.discountPercent.desc();
                 break;
-            default:
+            case "newest":
                 orderBy = buy.buyId.desc();
                 break;
+            default:
+                throw new CommerceException(CommerceErrorCode.INVALID_FILTER);
         }
 
         List<Tuple> results = jpaQueryFactory


### PR DESCRIPTION
### ⚡이슈 번호
resolve #75 

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 배송지 리스트 조회에서 category, cursor을 기본으로 받지 않아도 되도록 처리(required = false)
- cursor가 null일 경우 0으로 처리
- filter newest 추가 및 허용되지 않은 필터일 경우 에러문구 처리
---
### 📖 참고 사항
