### PR TITLE
공동구매 상품 상세페이지 조회 시 평균 리뷰점수 계산 방식 변경

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
@@ -83,13 +83,11 @@ public class QBuyRepositoryImpl implements QBuyRepository{
                         score.two,
                         score.three,
                         score.four,
-                        score.five,
-                        review.rating
+                        score.five
                 )
                 .from(buy)
                 .join(buy.product, product)
                 .join(product.store, store)
-                .leftJoin(review).on(review.buy.buyId.eq(buy.buyId))
                 .leftJoin(score).on(score.buy.buyId.eq(buy.buyId))
                 .where(buy.buyId.eq(buyId))
                 .fetchOne();
@@ -98,13 +96,21 @@ public class QBuyRepositoryImpl implements QBuyRepository{
             return null;
         }
 
-        Integer[] ratingCount = new Integer[]{
-                Optional.ofNullable(result.get(17, Integer.class)).orElse(0),
-                Optional.ofNullable(result.get(18, Integer.class)).orElse(0),
-                Optional.ofNullable(result.get(19, Integer.class)).orElse(0),
-                Optional.ofNullable(result.get(20, Integer.class)).orElse(0),
-                Optional.ofNullable(result.get(21, Integer.class)).orElse(0)
-        };
+        Integer one = Optional.ofNullable(result.get(17, Integer.class)).orElse(0);
+        Integer two = Optional.ofNullable(result.get(18, Integer.class)).orElse(0);
+        Integer three = Optional.ofNullable(result.get(19, Integer.class)).orElse(0);
+        Integer four = Optional.ofNullable(result.get(20, Integer.class)).orElse(0);
+        Integer five = Optional.ofNullable(result.get(21, Integer.class)).orElse(0);
+
+        Integer[] ratingCount = new Integer[]{one, two, three, four, five};
+
+        double average;
+
+        if (one + two + three + four + five == 0) {
+            average = 0.0;
+        } else {
+            average = (one + two * 2 + three * 3 + four * 4 + five * 5) / (double) (one + two + three + four + five);
+        }
 
         List<String> categoryList = jpaQueryFactory
                 .select(category.name)
@@ -134,7 +140,7 @@ public class QBuyRepositoryImpl implements QBuyRepository{
                 .reviewCount(result.get(15, Long.class))
                 .askCount(result.get(16, Long.class))
                 .ratingCount(ratingCount)
-                .rating(result.get(22, Double.class))
+                .rating(average)
                 .category(categories)
                 .build();
     }
@@ -248,7 +254,7 @@ public class QBuyRepositoryImpl implements QBuyRepository{
             query.where(cursorCondition);
             query.orderBy(orderBy, buy.buyId.desc());
         }
-        
+
         List<Tuple> results = query.fetch();
         List<GetBuyListResponseDto.ProductDto> products = new ArrayList<>();
         int count = 0;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/service/CommerceService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/service/CommerceService.java
@@ -72,6 +72,10 @@ public class CommerceService {
 
 
     public GetBuyResponseDto getBuyPage(User user, Long buyId) {
+        if (!buyRepository.existsById(buyId)) {
+            throw new CommerceException(CommerceErrorCode.CANNOT_FOUND_PRODUCT);
+        }
+
         return buyRepository.getBuyPageByBuyId(user.getUserId(), buyId);
     }
 


### PR DESCRIPTION
### ⚡이슈 번호
resolve #84 

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- Review가 여러 개 존재할 수 있어 단건조회가 불가능 하기 때문에, ratingCount 를 직접 계산하는 방식으로 변경
- 상품 상세페이지 조회 시 존재하지 않는 buyId의 경우 예외처리 추가
---
### 📖 참고 사항
