### PR TITLE
공동구매 상품 리뷰 응답 api 수정 / AT 유효기간 연장

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/dto/GetProductReviewResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/dto/GetProductReviewResponseDto.java
@@ -11,11 +11,13 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GetProductReviewResponseDto {
     private Double avg;
+    private Integer total;
     private List<ReviewDto> reviews;
 
     public static GetProductReviewResponseDto from(Double avg, List<ReviewDto> reviews) {
         return GetProductReviewResponseDto.builder()
                 .avg(avg)
+                .total(reviews.size())
                 .reviews(reviews)
                 .build();
     }
@@ -27,7 +29,7 @@ public class GetProductReviewResponseDto {
         private String nickname;
         private String content;
         private Integer rating;
-        private String reviewImg;
+        private String[] reviewImg;
         private LocalDateTime createdAt;
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
@@ -308,13 +308,14 @@ public class QBuyRepositoryImpl implements QBuyRepository{
                 .fetch();
 
         List<GetProductReviewResponseDto.ReviewDto> reviews = new ArrayList<>();
+
         for (Tuple tuple : result) {
             GetProductReviewResponseDto.ReviewDto reviewDto = GetProductReviewResponseDto.ReviewDto.builder()
                     .reviewId(tuple.get(0, Long.class))
                     .nickname(tuple.get(1, String.class))
                     .content(tuple.get(2, String.class))
                     .rating(tuple.get(3, Integer.class))
-                    .reviewImg(tuple.get(4, String.class))
+                    .reviewImg(tuple.get(4, String.class) != null ? tuple.get(4, String.class).split(",") : new String[0])
                     .createdAt(tuple.get(5, LocalDateTime.class))
                     .build();
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/service/CommerceService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/service/CommerceService.java
@@ -15,7 +15,6 @@ import dutchiepay.backend.domain.order.repository.AskRepository;
 import dutchiepay.backend.domain.order.repository.LikesRepository;
 import dutchiepay.backend.domain.order.repository.ProductRepository;
 import dutchiepay.backend.entity.*;
-import dutchiepay.backend.global.converter.BuyCategoryConverter;
 import dutchiepay.backend.global.security.UserDetailsImpl;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;

--- a/DutchiePay/src/main/resources/application.yml
+++ b/DutchiePay/src/main/resources/application.yml
@@ -77,7 +77,7 @@ jwt:
       key: ${JWT_REFRESH_KEY}
   access:
     token:
-      expiration: 1800000  # 30분
+      expiration: 604800000  # 7일 (30분 : 1800000)
   refresh:
     token:
       expiration: 604800000  # 7일


### PR DESCRIPTION
### ⚡이슈 번호
resolve #87 

---
### ✅ PR 종류
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 공동구매 상품 리뷰 조회 시 총 개수 및 리뷰 이미지 배열 형태로 전달
- 개발 단계 AT 유효기간 1주일로 연장
---
### 📖 참고 사항
