### PR TITLE
Long 타입 유효성 검사 시 NotNull 어노테이션으로 변경

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/dto/CancelPurchaseRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/dto/CancelPurchaseRequestDto.java
@@ -1,6 +1,7 @@
 package dutchiepay.backend.domain.order.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
@@ -8,6 +9,6 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CancelPurchaseRequestDto {
-    @NotBlank(message = "주문 ID를 입력해주세요.")
+    @NotNull(message = "주문 ID를 입력해주세요.")
     private Long orderId;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/dto/ConfirmPurchaseRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/dto/ConfirmPurchaseRequestDto.java
@@ -1,6 +1,6 @@
 package dutchiepay.backend.domain.order.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
@@ -8,6 +8,6 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ConfirmPurchaseRequestDto {
-    @NotBlank(message = "주문 ID를 입력해주세요.")
+    @NotNull(message = "주문 ID를 입력해주세요.")
     private Long orderId;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/dto/ExchangeRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/dto/ExchangeRequestDto.java
@@ -1,6 +1,7 @@
 package dutchiepay.backend.domain.order.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
@@ -10,7 +11,7 @@ import lombok.*;
 public class ExchangeRequestDto {
     @NotBlank(message = "교환 요청 타입을 입력해주세요.")
     private String type;
-    @NotBlank(message = "주문 ID를 입력해주세요.")
+    @NotNull(message = "주문 ID를 입력해주세요.")
     private Long orderId;
     @NotBlank(message = "교환 사유를 입력해주세요.")
     private String reason;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderService.java
@@ -24,7 +24,7 @@ public class OrderService {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new OrderErrorException(OrderErrorCode.INVALID_ORDER));
 
-        if (order.getUser() != user) {
+        if (!order.getUser().getUserId().equals(user.getUserId())) {
             throw new OrderErrorException(OrderErrorCode.ORDER_USER_MISS_MATCH);
         }
 
@@ -36,7 +36,7 @@ public class OrderService {
         Order order = orderRepository.findById(req.getOrderId())
                 .orElseThrow(() -> new OrderErrorException(OrderErrorCode.INVALID_ORDER));
 
-        if (order.getUser() != user) {
+        if (!order.getUser().getUserId().equals(user.getUserId())) {
             throw new OrderErrorException(OrderErrorCode.ORDER_USER_MISS_MATCH);
         }
 
@@ -61,7 +61,7 @@ public class OrderService {
         Order order = orderRepository.findById(req.getOrderId())
                 .orElseThrow(() -> new OrderErrorException(OrderErrorCode.INVALID_ORDER));
 
-        if (order.getUser() != user) {
+        if (!order.getUser().getUserId().equals(user.getUserId())) {
             throw new OrderErrorException(OrderErrorCode.ORDER_USER_MISS_MATCH);
         }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/CreateAskRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/CreateAskRequestDto.java
@@ -9,7 +9,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CreateAskRequestDto {
-    @NotBlank(message = "공구게시글 ID를 입력해주세요.")
+    @NotNull(message = "공구게시글 ID를 입력해주세요.")
     private Long buyId;
     @NotBlank(message = "문의 내용을 입력해주세요.")
     private String content;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/CreateReviewRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/CreateReviewRequestDto.java
@@ -1,6 +1,7 @@
 package dutchiepay.backend.domain.profile.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
@@ -8,11 +9,11 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CreateReviewRequestDto {
-    @NotBlank(message = "주문번호를 입력해주세요.")
+    @NotNull(message = "주문번호를 입력해주세요.")
     private Long orderId;
     @NotBlank(message = "리뷰 내용을 입력해주세요.")
     private String content;
-    @NotBlank(message = "평점을 입력해주세요.")
+    @NotNull(message = "평점을 입력해주세요.")
     private Integer rating;
     private String[] reviewImg;
 }


### PR DESCRIPTION
### ⚡이슈 번호
resolve #

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- NotBlank 어노테이션의 경우에는 String 타입에만 사용이 가능해 Long 타입의 요청 데이터들을 NotNull 어노테이션으로 변경했습니다.
- 주문자 정보와 유저가 일치하는지 파악 시 객체 판단 -> user의 id판단 으로 변경
---
### 📖 참고 사항
