### PR TITLE
fix | 유저 판단 시 userId를 통해 동일 여부 판단하도록 변경

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
@@ -77,7 +77,7 @@ public class ProfileService {
         Order order = orderRepository.findById(req.getOrderId())
                 .orElseThrow(() -> new OrderErrorException(OrderErrorCode.INVALID_ORDER));
 
-        if (user != order.getUser()) {
+        if (!order.getUser().getUserId().equals(user.getUserId())) {
             throw new ProfileErrorException(ProfileErrorCode.INVALID_USER_ORDER_REVIEW);
         }
 
@@ -157,31 +157,32 @@ public class ProfileService {
     public void deleteAsk(User user, Long askId) {
         Ask ask = askRepository.findById(askId).orElseThrow(() -> new AskErrorException(AskErrorCode.INVALID_ASK));
 
-        if (ask.getUser() != user) {
+        if (!ask.getUser().getUserId().equals(user.getUserId())) {
             throw new ProfileErrorException(ProfileErrorCode.DELETE_ASK_USER_MISSMATCH);
         }
 
         askRepository.softDelete(ask);
     }
 
+    @Transactional
     public void deleteReview(User user, Long reviewId) {
         Review review = reviewRepository.findById(reviewId).orElseThrow(() -> new ReviewErrorException(ReviewErrorCode.INVALID_REVIEW));
 
-        if (review.getUser() != user) {
+        if (!review.getUser().getUserId().equals(user.getUserId())) {
             throw new ProfileErrorException(ProfileErrorCode.DELETE_REVIEW_USER_MISSMATCH);
         }
 
         reviewRepository.softDelete(review);
     }
 
-
+    @Transactional
     public void updateReview(User user, UpdateReviewRequestDto req) {
         StringBuilder sb = new StringBuilder();
 
         Review review = reviewRepository.findById(req.getReviewId())
                 .orElseThrow(() -> new ReviewErrorException(ReviewErrorCode.INVALID_REVIEW));
 
-        if (review.getUser() != user) {
+        if (!review.getUser().getUserId().equals(user.getUserId())) {
             throw new ProfileErrorException(ProfileErrorCode.UPDATE_REVIEW_USER_MISSMATCH);
         }
 


### PR DESCRIPTION
### ⚡이슈 번호
resolve #116 

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
-
---
### 📖 참고 사항
