### PR TITLE
카카오페이 환불/결제 취소 로직 적용

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/exception/OrderErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/exception/OrderErrorCode.java
@@ -15,6 +15,8 @@ public enum OrderErrorCode implements StatusCode {
     INVALID_ORDER(HttpStatus.BAD_REQUEST, "주문정보를 찾을 수 없습니다."),
     INVALID_EXCHANGE_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 교환 요청 타입입니다."),
     NOT_DELIVERED(HttpStatus.BAD_REQUEST, "배송이 완료되지 않았습니다"),
+    INVALID_PAYMENT(HttpStatus.BAD_REQUEST, "올바르지 않은 결제 정보입니다."),
+    KAKAOPAY_CANCEL_FAILED(HttpStatus.BAD_REQUEST, "카카오페이 결제 취소에 실패하였습니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/repository/QAskRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/repository/QAskRepositoryImpl.java
@@ -38,6 +38,7 @@ public class QAskRepositoryImpl implements QAskRepository{
                 .join(ask.buy)
                 .join(ask.product.store)
                 .where(ask.user.eq(user))
+                .where(ask.deletedAt.isNull())
                 .fetch();
 
         List<GetMyAskResponseDto> result = new ArrayList<>();

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/repository/ReviewRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/repository/ReviewRepository.java
@@ -20,4 +20,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, QReviewRe
     void softDelete(Review review);
 
     boolean existsByUserAndOrder(User user, Order order);
+
+    boolean existsByUserAndOrderAndDeletedAtIsNull(User user, Order order);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderService.java
@@ -97,7 +97,7 @@ public class OrderService {
             }
         } else if (order.getPayment().equals("kakao")) {
             if (kakaoPayService.cancelExchange(order.getOrderNum(), "취소완료")) {
-                buy.disCount();
+                buy.disCount(order.getQuantity());
             } else {
                 throw new OrderErrorException(OrderErrorCode.KAKAOPAY_CANCEL_FAILED);
             }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderService.java
@@ -38,7 +38,7 @@ public class OrderService {
             throw new OrderErrorException(OrderErrorCode.ORDER_USER_MISS_MATCH);
         }
 
-        order.confirmPurchase();
+        order.changeStatus("구매확정");
     }
 
     @Transactional
@@ -58,7 +58,7 @@ public class OrderService {
 
         // 환불일때만 결제 취소 진행
         if (req.getType().equals("환불")) {
-            if (order.getPayment().equals("kakao")) kakaoPayService.kakaoPayCancel(order.getOrderNum());
+            if (order.getPayment().equals("kakao")) kakaoPayService.cancelExchange(order, "환불처리");
             else if (order.getPayment().equals("card")) {
                 tossPaymentsService.cancelPayment(order);
                 order.changeStatus("환불처리");
@@ -90,10 +90,19 @@ public class OrderService {
         if (buy.getDeadline().isAfter(LocalDate.now()) && buy.getNowCount() >= buy.getSkeleton())
             throw new CommerceException(CommerceErrorCode.SUCCEEDED_BUY);
 
-        if (order.getPayment().equals("card"))
-            if (tossPaymentsService.cancelPayment(order)){
+        if (order.getPayment().equals("card")) {
+            if (tossPaymentsService.cancelPayment(order)) {
                 order.changeStatus("취소완료");
                 buy.disCount();
             }
+        } else if (order.getPayment().equals("kakao")) {
+            if (kakaoPayService.cancelExchange(order.getOrderNum(), "취소완료")) {
+                buy.disCount();
+            } else {
+                throw new OrderErrorException(OrderErrorCode.KAKAOPAY_CANCEL_FAILED);
+            }
+        } else {
+            throw new OrderErrorException(OrderErrorCode.INVALID_PAYMENT);
+        }
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
@@ -81,7 +81,7 @@ public class ProfileService {
             throw new ProfileErrorException(ProfileErrorCode.INVALID_USER_ORDER_REVIEW);
         }
 
-        if (reviewRepository.existsByUserAndOrder(user, order)) {
+        if (reviewRepository.existsByUserAndOrderAndDeletedAtIsNull(user, order)) {
             throw new ReviewErrorException(ReviewErrorCode.ALREADY_EXIST);
         }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Order.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Order.java
@@ -71,29 +71,9 @@ public class Order extends Auditing {
     @Column(nullable = false)
     private int quantity;
 
-    public void confirmPurchase() {
-        this.state = "구매확정";
-    }
-
-    public void cancelPurchase() {
-        this.state = "주문취소";
-    }
-
     public void readyPurchase(String tid) {
         this.tid = tid;
         this.state = "결제준비";
-    }
-
-    public void approvePayment() {
-        this.state = "결제완료";
-    }
-
-    public void cancelPayment() {
-        this.state = "결제취소";
-    }
-
-    public void failPayment() {
-        this.state = "결제실패";
     }
 
     public void changeStatus(String state) {

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/payment/controller/PaymentController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/payment/controller/PaymentController.java
@@ -47,7 +47,7 @@ public class PaymentController {
     public void approve(HttpServletResponse response,
                         @RequestParam("pg_token") String pgToken,
                         @RequestParam("orderNum") String orderNum) throws IOException {
-        ApproveResponseDto result = kakaoPayService.kakaoPayApprove(pgToken, orderNum);
+        kakaoPayService.kakaoPayApprove(pgToken, orderNum);
 
         response.setContentType(POST_MESSAGE_CONTENT_TYPE);
         response.getWriter().write(kakaoPayService.makePostMessage(orderNum, PAYMENT_APPROVE_STATUS));
@@ -58,19 +58,10 @@ public class PaymentController {
     @PreAuthorize("permitAll()")
     public void cancel(HttpServletResponse response,
                          @RequestParam("orderNum") String orderNum) throws IOException {
-        // 결제내역조회(/v1/payment/status) api에서 status를 확인한다.
-        String status = kakaoPayService.kakaPayCheckStatus(orderNum);
-
-        // 승인되지 않은 경우(결제 x인 경우) -> 취소 불가능 (상태코드 : READY)
-        // 승인 된 경우 -> 취소 가능 (상태코드 : SUCCESS_PAYMENT)
-        // 이미 취소 된 경우 -> 취소 불가능 (상태코드 : CANCEL_PAYMENT)
-        if (status.equals("SUCCESS_PAYMENT")) {
-            kakaoPayService.kakaoPayCancel(orderNum);
-
+        if (kakaoPayService.cancelExchange(orderNum, "취소완료")) {
             response.setContentType(POST_MESSAGE_CONTENT_TYPE);
             response.getWriter().write(kakaoPayService.makePostMessage(orderNum, PAYMENT_CANCEL_STATUS));
             response.getWriter().flush();
-        } else if (status.equals("CANCEL_PAYMENT")) {
         }
     }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/payment/exception/PaymentErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/payment/exception/PaymentErrorCode.java
@@ -15,7 +15,14 @@ public enum PaymentErrorCode {
     INVALID_PRODUCT(HttpStatus.BAD_REQUEST, "상품 정보가 없습니다."),
     INVALID_BUY(HttpStatus.BAD_REQUEST, "구매 정보가 없습니다."),
     FINISHED_PAYMENT(HttpStatus.BAD_REQUEST, "이미 처리된 요청입니다."),
-    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "정보가 유효하지 않습니다.");
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "정보가 유효하지 않습니다."),
+    INVALID_KAKAO_CANCEL_STATUS(HttpStatus.BAD_REQUEST, "카카오페이 결제를 할 수 없는 상태입니다."),
+
+    /**
+     * 500 INTERNAL_SERVER_ERROR
+     */
+    ERROR_KAKAOPAY_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "카카오페이 결제 상태를 확인할 수 없습니다."),
+    ERROR_KAKAOPAY_CANCEL(HttpStatus.INTERNAL_SERVER_ERROR, "카카오페이 결제 취소 중 오류가 발생하였습니다."),;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/payment/service/KakaoPayService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/payment/service/KakaoPayService.java
@@ -135,7 +135,7 @@ public class KakaoPayService {
                     ApproveResponseDto.class
             );
 
-            order.approvePayment();
+            order.changeStatus("결제완료");
 
             return response.getBody();
         } catch (HttpStatusCodeException ex) {
@@ -143,11 +143,33 @@ public class KakaoPayService {
         }
     }
 
-    @Transactional
-    public void kakaoPayCancel(String orderNum) {
+    public boolean cancelExchange(Order order, String orderState) {
+        String status = kakaPayCheckStatus(order);
+
+        if (status.equals("SUCCESS_PAYMENT")) {
+            kakaoPayCancel(order, orderState);
+            return true;
+        } else {
+            throw new PaymentErrorException(PaymentErrorCode.INVALID_KAKAO_CANCEL_STATUS);
+        }
+    }
+
+    public boolean cancelExchange(String orderNum, String orderState) {
         Order order = ordersRepository.findByOrderNum(orderNum)
                 .orElseThrow(() -> new OrderErrorException(OrderErrorCode.INVALID_ORDER));
 
+        String status = kakaPayCheckStatus(order);
+
+        if (status.equals("SUCCESS_PAYMENT")) {
+            kakaoPayCancel(order, orderState);
+            return true;
+        } else {
+            throw new PaymentErrorException(PaymentErrorCode.INVALID_KAKAO_CANCEL_STATUS);
+        }
+    }
+
+    @Transactional
+    protected void kakaoPayCancel(Order order, String state) {
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", "SECRET_KEY " + secretKey);
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -168,10 +190,11 @@ public class KakaoPayService {
                     CancelResponseDto.class
             );
 
-            order.cancelPayment();
+            order.changeStatus(state);
             log.info("response: {}", response.getBody());
         } catch (HttpStatusCodeException ex) {
             log.error("카카오페이 결제 취소 실패: Status code: {}, Response body: {}", ex.getStatusCode(), ex.getResponseBodyAsString());
+            throw new PaymentErrorException(PaymentErrorCode.ERROR_KAKAOPAY_CANCEL);
         }
     }
 
@@ -200,9 +223,34 @@ public class KakaoPayService {
             return response.getBody().getStatus();
         } catch (HttpStatusCodeException ex) {
             log.error("카카오페이 결제 상태 조회 실패");
+            throw new PaymentErrorException(PaymentErrorCode.ERROR_KAKAOPAY_STATUS);
         }
+    }
 
-        return null;
+    public String kakaPayCheckStatus(Order order) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "SECRET_KEY " + secretKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        KakaoPayCheckStatusRequest request = KakaoPayCheckStatusRequest.builder()
+                .cid(cid)
+                .tid(order.getTid())
+                .build();
+
+        HttpEntity<KakaoPayCheckStatusRequest> entityMap = new HttpEntity<>(request, headers);
+
+        try {
+            ResponseEntity<KakaoPayCheckStatusResponse> response = new RestTemplate().postForEntity(
+                    "https://open-api.kakaopay.com/online/v1/payment/order",
+                    entityMap,
+                    KakaoPayCheckStatusResponse.class
+            );
+
+            return response.getBody().getStatus();
+        } catch (HttpStatusCodeException ex) {
+            log.error("카카오페이 결제 상태 조회 실패");
+            throw new PaymentErrorException(PaymentErrorCode.ERROR_KAKAOPAY_STATUS);
+        }
     }
 
     public String makePostMessage(String orderNum, String paymentStatus) {
@@ -242,6 +290,6 @@ public class KakaoPayService {
         Order order = ordersRepository.findByOrderNum(orderNum)
                 .orElseThrow(() -> new OrderErrorException(OrderErrorCode.INVALID_ORDER));
 
-        order.failPayment();
+        order.changeStatus("결제실패");
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/payment/service/KakaoPayService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/payment/service/KakaoPayService.java
@@ -148,6 +148,7 @@ public class KakaoPayService {
 
         if (status.equals("SUCCESS_PAYMENT")) {
             kakaoPayCancel(order, orderState);
+            order.getBuy().disCount(order.getQuantity());
             return true;
         } else {
             throw new PaymentErrorException(PaymentErrorCode.INVALID_KAKAO_CANCEL_STATUS);
@@ -162,6 +163,7 @@ public class KakaoPayService {
 
         if (status.equals("SUCCESS_PAYMENT")) {
             kakaoPayCancel(order, orderState);
+            order.getBuy().disCount(order.getQuantity());
             return true;
         } else {
             throw new PaymentErrorException(PaymentErrorCode.INVALID_KAKAO_CANCEL_STATUS);

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/payment/service/KakaoPayService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/payment/service/KakaoPayService.java
@@ -135,7 +135,8 @@ public class KakaoPayService {
                     ApproveResponseDto.class
             );
 
-            order.changeStatus("결제완료");
+            order.changeStatus("공구진행중");
+            order.getBuy().upCount(order.getQuantity());
 
             return response.getBody();
         } catch (HttpStatusCodeException ex) {


### PR DESCRIPTION
### ⚡이슈 번호
resolve #121 

---
### ✅ PR 종류
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 환불 때와 결제 취소 때를 다르게 하여 로직을 적용했습니다
- 문의 조회 시 deletedAt이 null인 항목만 반환하도록 하였습니다
- 리뷰를 작성 한 후에 삭제를 하더라도 리뷰를 재작성할 수 있도록 했습니다.
---
### 📖 참고 사항
