### PR TITLE
후기 삭제 문제 해결 / ec2 한국 시간대 적용 / 구매 목록 필터링 조건 체크 시 Null 유무 체크

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
@@ -76,7 +76,8 @@ public class QBuyRepositoryImpl implements QBuyRepository{
                         JPAExpressions
                                 .select(ask.count())
                                 .from(ask)
-                                .where(ask.buy.buyId.eq(buyId)),
+                                .where(ask.buy.buyId.eq(buyId))
+                                .where(ask.deletedAt.isNull()),
                         score.one,
                         score.two,
                         score.three,

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/controller/ProfileController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/controller/ProfileController.java
@@ -36,7 +36,7 @@ public class ProfileController {
     public ResponseEntity<?> myGoods(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                    @RequestParam(name = "page") Long page,
                                    @RequestParam(name = "limit") Long limit,
-                                     @RequestParam(name = "filter", required = false) String filter) {
+                                   @RequestParam(name = "filter", required = false) String filter) {
         return ResponseEntity.ok().body(profileService.getMyGoods(userDetails.getUser(), page, limit, filter));
     }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/exception/ProfileErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/exception/ProfileErrorCode.java
@@ -18,7 +18,7 @@ public enum ProfileErrorCode implements StatusCode {
     INVALID_POST_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 게시글 타입입니다."),
     INVALID_USER_ORDER_REVIEW(HttpStatus.BAD_REQUEST, "자신이 구매한 상품에만 후기를 달 수 있습니다."),
     INVALID_USER_ORDER_ASK(HttpStatus.BAD_REQUEST, "자신이 구매한 상품에만 문의를 달 수 있습니다."),
-    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "올바르지 않은 주문 상태입니다."),
+    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "올바르지 않은 필터입니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
@@ -35,9 +35,10 @@ public class ProfileService {
     }
 
     public List<MyGoodsResponseDto> getMyGoods(User user, Long page, Long limit, String filter) {
-        if (!(filter.equals("pending") || filter.equals("shipped") || filter.equals("delivered"))) {
-            throw new ProfileErrorException(ProfileErrorCode.INVALID_ORDER_STATUS);
-        }
+        if (filter != null && !(filter.equals("pending") || filter.equals("shipped") || filter.equals("delivered"))) {
+                throw new ProfileErrorException(ProfileErrorCode.INVALID_ORDER_STATUS);
+            }
+
         return profileRepository.getMyGoods(user, filter, PageRequest.of(page.intValue() - 1, limit.intValue()));
     }
 


### PR DESCRIPTION
### ⚡이슈 번호
resolve #130

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- ec2에서 스프링을 배포 시에 한국 시간대를 적용하기 위해 -Duser.timezone=Asia/Seoul 옵션을 추가하였습니다
- soft delete 된 문의 목록을 count하지 않도록 where 절을 추가하였습니다
- 구매 목록 전체 조회 시 filter값으로 null 이 되기 때문에, 필터링 조건에서 null이 아닌 경우 조건을 추가했습니다.
---
### 📖 참고 사항
