### PR TITLE
127/fix commerce

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderService.java
@@ -96,9 +96,7 @@ public class OrderService {
                 buy.disCount(order.getQuantity());
             }
         } else if (order.getPayment().equals("kakao")) {
-            if (kakaoPayService.cancelExchange(order.getOrderNum(), "취소완료")) {
-                buy.disCount(order.getQuantity());
-            } else {
+            if (!kakaoPayService.cancelExchange(order.getOrderNum(), "취소완료")) {
                 throw new OrderErrorException(OrderErrorCode.KAKAOPAY_CANCEL_FAILED);
             }
         } else {

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderService.java
@@ -87,7 +87,7 @@ public class OrderService {
             throw new OrderErrorException(OrderErrorCode.ORDER_USER_MISS_MATCH);
         }
 
-        if (buy.getDeadline().isAfter(LocalDate.now()) && buy.getNowCount() >= buy.getSkeleton())
+        if (buy.getDeadline().isBefore(LocalDate.now()) && buy.getNowCount() >= buy.getSkeleton())
             throw new CommerceException(CommerceErrorCode.SUCCEEDED_BUY);
 
         if (order.getPayment().equals("card")) {

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
@@ -52,6 +52,7 @@ public class QProfileRepositoryImpl implements QProfileRepository {
     QComment comment = QComment.comment;
     QBuyCategory buyCategory = QBuyCategory.buyCategory;
     QCategory category = QCategory.category;
+    QReview review = QReview.review;
 
 
     @Override
@@ -77,7 +78,12 @@ public class QProfileRepositoryImpl implements QProfileRepository {
                                         .from(score)
                                         .where(score.buy.eq(buy)), "rating"
                         ),
-                        score.count,
+                        ExpressionUtils.as(
+                                JPAExpressions
+                                        .select(review.count().castToNum(Integer.class))
+                                        .from(review)
+                                        .where(review.order.buy.eq(buy)), "reviewCount"
+                        ),
                         ExpressionUtils.as(
                                 Expressions.numberTemplate(
                                         Integer.class,


### PR DESCRIPTION
### ⚡이슈 번호
resolve #

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 환불 시 구매 수량이 음수 값이 되는 오류 수정
- 마감되지 않은 상품이 목표 수량 이상만큼 판매됐을 때 구매취소가 되지 않는 오류 수정
- 좋아요한 상품 목록 reviewCount 0일 경우 null로 반환되는 오류 수정
---
### 📖 참고 사항
