### PR TITLE
구매 내역 확인 시 구매 내역 존재여부에 따른 에러 응답 분기점 생성

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/exception/ProfileErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/exception/ProfileErrorCode.java
@@ -29,7 +29,13 @@ public enum ProfileErrorCode implements StatusCode {
      * 403 FORBIDDEN
      */
     DELETE_REVIEW_USER_MISSMATCH(HttpStatus.FORBIDDEN, "본인만 후기 삭제를 할 수 있습니다."),
-    UPDATE_REVIEW_USER_MISSMATCH(HttpStatus.FORBIDDEN, "본인만 후기 수정을 할 수 있습니다.");
+    UPDATE_REVIEW_USER_MISSMATCH(HttpStatus.FORBIDDEN, "본인만 후기 수정을 할 수 있습니다."),
+
+    /**
+     * 404 NOT_FOUND
+     */
+    NO_HISTORY_ORDER(HttpStatus.NOT_FOUND, "주문 내역이 없습니다."),
+    NO_MORE_HISTORY_ORDER(HttpStatus.NOT_FOUND, "더 이상 주문 내역이 없습니다."),;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
@@ -152,9 +152,6 @@ public class QProfileRepositoryImpl implements QProfileRepository {
 
     @Override
     public List<MyGoodsResponseDto> getMyGoods(User user, String filter, Pageable pageable) {
-
-        System.out.println("pageable = " + pageable.getPageNumber());
-
         BooleanExpression filterCondition = getMyGoodsFilterCondition(filter);
 
         List<Tuple> tuple =  jpaQueryFactory

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
@@ -12,6 +12,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import dutchiepay.backend.domain.profile.dto.GetMyLikesResponseDto;
 import dutchiepay.backend.domain.profile.dto.MyGoodsResponseDto;
 import dutchiepay.backend.domain.profile.dto.MyPostsResponseDto;
+import dutchiepay.backend.domain.profile.exception.ProfileErrorCode;
+import dutchiepay.backend.domain.profile.exception.ProfileErrorException;
 import dutchiepay.backend.entity.*;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -151,6 +153,8 @@ public class QProfileRepositoryImpl implements QProfileRepository {
     @Override
     public List<MyGoodsResponseDto> getMyGoods(User user, String filter, Pageable pageable) {
 
+        System.out.println("pageable = " + pageable.getPageNumber());
+
         BooleanExpression filterCondition = getMyGoodsFilterCondition(filter);
 
         List<Tuple> tuple =  jpaQueryFactory
@@ -182,9 +186,12 @@ public class QProfileRepositoryImpl implements QProfileRepository {
 
         List<MyGoodsResponseDto> result = new ArrayList<>();
 
-        if (tuple.isEmpty()) {
-            return result;
+        if (pageable.getPageNumber() == 0 && tuple.isEmpty()) {
+            throw new ProfileErrorException(ProfileErrorCode.NO_HISTORY_ORDER);
+        } else if (tuple.isEmpty()) {
+            throw new ProfileErrorException(ProfileErrorCode.NO_MORE_HISTORY_ORDER);
         }
+
 
         for (Tuple t : tuple) {
             MyGoodsResponseDto dto = MyGoodsResponseDto.builder()


### PR DESCRIPTION
### ⚡이슈 번호
resolve #134 

---
### ✅ PR 종류
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 현재 구매 목록 조회 시에 내용이 없을 경우 빈 배열 응답이 가고 있었습니다.
- 하지만, 회원이 아무것도 구매한 것이 없는 회원인지, 구매 목록 페이지의 끝에 도달해서 더 이상 주문 내역이 없는 것인지 판단하기가 힘들기 때문에 에러 코드를 통해 이를 안내하도록 하였습니다.
<img width="922" alt="스크린샷 2024-11-15 오후 5 45 47" src="https://github.com/user-attachments/assets/ee97541c-d103-4a8e-8da7-6e1fd9bd5350">
<img width="882" alt="스크린샷 2024-11-15 오후 5 45 55" src="https://github.com/user-attachments/assets/dacc8d3b-647a-4976-bcb1-765c3bf8205b">

- 페이지가 1이고, 빈 배열일 경우 -> 주문 내역 자체가 없음
- 페이지가 1이 아니고, 빈 배열일 경우 -> 주문 내역의 끝에 도달해서 더 이상 주문 내역이 없음
---
### 📖 참고 사항
