### PR TITLE
마감임박순 필터 시 오늘마감되는 데이터도 먼저 보여지도록 변경

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
@@ -209,7 +209,7 @@ public class QBuyRepositoryImpl implements QBuyRepository{
                     Tuple cursorInfo = jpaQueryFactory
                             .select(buy.deadline,
                                     Expressions.cases()
-                                            .when(buy.deadline.after(LocalDate.now()))
+                                            .when(buy.deadline.goe(LocalDate.now()))
                                             .then(0)
                                             .otherwise(1))
                             .from(buy)
@@ -221,7 +221,7 @@ public class QBuyRepositoryImpl implements QBuyRepository{
                         Integer cursorGroup = cursorInfo.get(1, Integer.class);
 
                         BooleanExpression sameGroupCondition = Expressions.cases()
-                                .when(buy.deadline.after(LocalDate.now()))
+                                .when(buy.deadline.goe(LocalDate.now()))
                                 .then(0)
                                 .otherwise(1)
                                 .eq(cursorGroup)
@@ -230,7 +230,7 @@ public class QBuyRepositoryImpl implements QBuyRepository{
                                     .and(buy.buyId.loe(cursor))));
 
                         BooleanExpression nextGroupCondition = Expressions.cases()
-                                .when(buy.deadline.after(LocalDate.now()))
+                                .when(buy.deadline.goe(LocalDate.now()))
                                 .then(0)
                                 .otherwise(1)
                                 .gt(cursorGroup);
@@ -241,7 +241,7 @@ public class QBuyRepositoryImpl implements QBuyRepository{
 
                 orderBy = new OrderSpecifier[]{
                         Expressions.cases()
-                                .when(buy.deadline.after(LocalDate.now()))
+                                .when(buy.deadline.goe(LocalDate.now()))
                                 .then(0)
                                 .otherwise(1)
                                 .asc(),


### PR DESCRIPTION
### ⚡이슈 번호
resolve #137 

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 마감임박순 데이터를 그룹화하여 나눌 때 (마감이전 데이터 / 마감된 데이터) 로 나누게 되는데, 이 경우 마감이전 데이터를 판별하는 로직에서 after을 사용하여 오늘 마감되는 데이터가 보여지지 않음
- 따라서 이를 해결하기 위해, >= 옵션인 goe로 변경
---
### 📖 참고 사항
