### PR TITLE
스케쥴링 기능 실행 시 쿼리 조건문 일부 변경 / 카카오페이 서비스 로직 관심사 분리

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/repository/OrderRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/repository/OrderRepository.java
@@ -17,12 +17,12 @@ public interface OrderRepository extends JpaRepository<Order, Long>, QOrderRepos
 
     List<Order> findAllByState(String inProgress);
 
-    @Query("SELECT o FROM Order o WHERE o.state = :state AND o.buy.deadline < :targetDate")
+    @Query("SELECT o FROM Order o WHERE o.state = :state AND o.buy.deadline <= :targetDate")
     List<Order> findPreparingShipmentOrders(String state, LocalDate targetDate);
 
-    @Query("SELECT o FROM Order o WHERE o.state IN :states AND o.statusChangeDate >= :targetDate")
+    @Query("SELECT o FROM Order o WHERE o.state IN :states AND o.statusChangeDate <= :targetDate")
     List<Order> findShippingOrders(List<String> states, LocalDate targetDate);
 
-    @Query("SELECT o FROM Order o WHERE o.state = :state AND o.statusChangeDate >= :targetDate")
+    @Query("SELECT o FROM Order o WHERE o.state = :state AND o.statusChangeDate <= :targetDate")
     List<Order> findCompletedOrders(String state, LocalDate targetDate);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderService.java
@@ -119,10 +119,10 @@ public class OrderService {
 
         if (order.getPayment().equals("card")) {
             if (tossPaymentsService.cancelPayment(order)) {
-                order.changeStatus("취소완료");
+                order.changeStatus("공구실패");
             }
         } else if (order.getPayment().equals("kakao")) {
-            cancelKakaoPayExchange(order, "취소완료");
+            cancelKakaoPayExchange(order, "공구실패");
         } else {
             throw new OrderErrorException(OrderErrorCode.INVALID_PAYMENT);
         }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderService.java
@@ -116,16 +116,14 @@ public class OrderService {
         if (order.getPayment().equals("card")) {
             if (tossPaymentsService.cancelPayment(order)) {
                 order.changeStatus("취소완료");
-                buy.disCount(order.getQuantity());
             }
         } else if (order.getPayment().equals("kakao")) {
-            if (kakaoPayService.cancelExchange(order.getOrderNum(), "취소완료")) {
-                buy.disCount(order.getQuantity());
-            } else {
+            if (!kakaoPayService.cancelExchange(order.getOrderNum(), "취소완료")) {
                 throw new OrderErrorException(OrderErrorCode.KAKAOPAY_CANCEL_FAILED);
             }
         } else {
             throw new OrderErrorException(OrderErrorCode.INVALID_PAYMENT);
         }
+        buy.disCount(order.getQuantity());
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderService.java
@@ -67,6 +67,8 @@ public class OrderService {
             }
         }
 
+        order.getBuy().disCount(order.getQuantity());
+
         Refund newRefund = Refund.builder()
                 .user(user)
                 .store(order.getProduct().getStore())
@@ -98,7 +100,7 @@ public class OrderService {
                 buy.disCount(order.getQuantity());
             }
         } else if (order.getPayment().equals("kakao")) {
-            if (!kakaoPayService.cancelExchange(order.getOrderNum(), "취소완료")) {
+            if (!kakaoPayService.kakaoPayCancel(order, "취소완료")) {
                 throw new OrderErrorException(OrderErrorCode.KAKAOPAY_CANCEL_FAILED);
             }
         } else {
@@ -128,7 +130,7 @@ public class OrderService {
     }
 
     private void cancelKakaoPayExchange(Order order, String orderState) {
-        String status = kakaoPayService.kakaPayCheckStatus(order);
+        String status = kakaoPayService.kakaoPayCheckStatus(order);
 
         if (status.equals("SUCCESS_PAYMENT")) {
             kakaoPayService.kakaoPayCancel(order, orderState);

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Buy.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Buy.java
@@ -43,6 +43,10 @@ public class Buy extends Auditing {
     }
 
     public void disCount(int count) {
-        this.nowCount -= count;
+        if (count >= this.nowCount) {
+            this.nowCount = 0;
+        } else {
+            this.nowCount -= count;
+        }
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Buy.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Buy.java
@@ -43,10 +43,6 @@ public class Buy extends Auditing {
     }
 
     public void disCount(int count) {
-        if (count >= this.nowCount) {
-            this.nowCount = 0;
-        } else {
-            this.nowCount -= count;
-        }
+        this.nowCount = this.nowCount < count ? 0 : this.nowCount - count;
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/payment/controller/PaymentController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/payment/controller/PaymentController.java
@@ -58,7 +58,7 @@ public class PaymentController {
     @PreAuthorize("permitAll()")
     public void cancel(HttpServletResponse response,
                          @RequestParam("orderNum") String orderNum) throws IOException {
-        if (kakaoPayService.cancelExchange(orderNum, "취소완료")) {
+        if (kakaoPayService.kakaoPayCancel(orderNum, "취소완료")) {
             response.setContentType(POST_MESSAGE_CONTENT_TYPE);
             response.getWriter().write(kakaoPayService.makePostMessage(orderNum, PAYMENT_CANCEL_STATUS));
             response.getWriter().flush();
@@ -69,7 +69,7 @@ public class PaymentController {
     @PreAuthorize("permitAll()")
     public void fail(HttpServletResponse response,
                        @RequestParam("orderNum") String orderNum) throws IOException {
-        String status = kakaoPayService.kakaPayCheckStatus(orderNum);
+        String status = kakaoPayService.kakaoPayCheckStatus(orderNum);
 
         if (status.equals("FAIL_PAYMENT")) {
             kakaoPayService.kakaoPayFail(orderNum);

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/payment/exception/PaymentErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/payment/exception/PaymentErrorCode.java
@@ -21,9 +21,10 @@ public enum PaymentErrorCode {
     /**
      * 500 INTERNAL_SERVER_ERROR
      */
+    PORTONE_CANCEL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제 취소에 실패하였습니다."),
+    INVALID_KAKAO_APPROVE_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "카카오페이 결제 승인 응답이 유효하지 않습니다."),
     ERROR_KAKAOPAY_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "카카오페이 결제 상태를 확인할 수 없습니다."),
-    ERROR_KAKAOPAY_CANCEL(HttpStatus.INTERNAL_SERVER_ERROR, "카카오페이 결제 취소 중 오류가 발생하였습니다."),
-    PORTONE_CANCEL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제 취소에 실패하였습니다.");
+    ERROR_KAKAOPAY_CANCEL(HttpStatus.INTERNAL_SERVER_ERROR, "카카오페이 결제 취소 중 오류가 발생하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/payment/service/KakaoPayRequestService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/payment/service/KakaoPayRequestService.java
@@ -1,0 +1,198 @@
+package dutchiepay.backend.global.payment.service;
+
+import dutchiepay.backend.domain.commerce.repository.BuyRepository;
+import dutchiepay.backend.domain.order.repository.OrderRepository;
+import dutchiepay.backend.entity.Buy;
+import dutchiepay.backend.entity.Order;
+import dutchiepay.backend.entity.User;
+import dutchiepay.backend.global.payment.dto.kakao.*;
+import dutchiepay.backend.global.payment.exception.PaymentErrorCode;
+import dutchiepay.backend.global.payment.exception.PaymentErrorException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoPayRequestService {
+    private final OrderRepository ordersRepository;
+    private final BuyRepository buyRepository;
+
+    @Value("${host.backend}")
+    private String backendHost;
+
+    @Value("${payment.kakao.cid}")
+    private String cid;
+
+    @Value("${payment.kakao.secret}")
+    private String secretKey;
+
+    // 카카오페이 결제를 시작하기 위해 결제정보를 카카오페이 서버에 전달하고 결제 고유번호(TID)와 URL을 응답받는 단계
+    @Transactional
+    public KakaoPayReadyResponseDto ready(User user, ReadyRequestDto req) {
+        Buy buy = buyRepository.findById(req.getBuyId())
+                .orElseThrow(() -> new PaymentErrorException(PaymentErrorCode.INVALID_BUY));
+
+        Order newOrder = Order.builder()
+                .user(user)
+                .product(buy.getProduct())
+                .buy(buy)
+                .receiver(req.getReceiver())
+                .phone(req.getPhone())
+                .zipCode(req.getZipCode())
+                .address(req.getAddress())
+                .detail(req.getDetail())
+                .message(req.getMessage())
+                .totalPrice(req.getTotalAmount())
+                .payment("kakao")
+                .orderedAt(LocalDateTime.now())
+                .state("주문완료")
+                .quantity(req.getQuantity())
+                .orderNum(generateOrderNumber())
+                .build();
+
+        ordersRepository.save(newOrder);
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add("Authorization", "SECRET_KEY " + secretKey);
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+        KakaoPayReadyRequest body = KakaoPayReadyRequest.builder()
+                .cid(cid) // 가맹점 코드(테스트용은 TC0ONETIME)
+                .partnerOrderId(newOrder.getOrderNum()) // 가맹점 주문번호
+                .partnerUserId(user.getNickname()) // 회원 id
+                .itemName(req.getProductName()) // 상품명
+                .quantity(req.getQuantity()) // 수량
+                .totalAmount(req.getTotalAmount()) // 상품 총액
+                .taxFreeAmount(req.getTaxFreeAmount()) // 비과세 금액
+                .approvalUrl(backendHost + "/pay/kakao/approve?orderNum=" + newOrder.getOrderNum()) // 결제 성공시 redirect url
+                .cancelUrl(backendHost + "/pay/kakao/cancel?orderNum=" + newOrder.getOrderNum()) // 결제 취소시 redirect url
+                .failUrl(backendHost + "/pay/kakao/fail?orderNum=" + newOrder.getOrderNum()) // 결제 실패시 redirect url
+                .build();
+
+        HttpEntity<KakaoPayReadyRequest> requestEntity = new HttpEntity<>(body, httpHeaders);
+        ResponseEntity<ReadyResponseDto> response = new RestTemplate().postForEntity(
+                "https://open-api.kakaopay.com/online/v1/payment/ready",
+                requestEntity,
+                ReadyResponseDto.class
+        );
+
+        ReadyResponseDto readyResponse = response.getBody();
+
+        newOrder.readyPurchase(readyResponse.getTid());
+
+        return KakaoPayReadyResponseDto.from(readyResponse.getNext_redirect_pc_url());
+    }
+
+    // 사용자가 결제 수단을 선택하고 비밀번호를 입력해 결제 인증을 완료한 뒤, 최종적으로 결제 완료 처리를 하는 단계입니다.
+    // 인증완료 시 응답받은 pg_token과 tid로 최종 승인요청합니다.
+    // 결제 승인 API를 호출하면 결제 준비 단계에서 시작된 결제 건이 승인으로 완료 처리됩니다.
+    // 결제 승인 요청이 실패하면 카드사 등 결제 수단의 실패 정보가 필요에 따라 포함될 수 있습니다.
+    @Transactional
+    public ApproveResponseDto approve(String pgToken, Order order) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "SECRET_KEY " + secretKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        KakaoPayApproveRequest approveRequest = KakaoPayApproveRequest.builder()
+                .cid(cid)
+                .tid(order.getTid())
+                .partnerOrderId(order.getOrderNum())
+                .partnerUserId(order.getUser().getNickname())
+                .pgToken(pgToken)
+                .build();
+
+        HttpEntity<KakaoPayApproveRequest> entityMap = new HttpEntity<>(approveRequest, headers);
+        try {
+            ResponseEntity<ApproveResponseDto> response = new RestTemplate().postForEntity(
+                    "https://open-api.kakaopay.com/online/v1/payment/approve",
+                    entityMap,
+                    ApproveResponseDto.class
+            );
+
+            return response.getBody();
+        } catch (HttpStatusCodeException ex) {
+            return null;
+        }
+    }
+
+    @Transactional
+    public boolean cancel(Order order) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "SECRET_KEY " + secretKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        KakaoPayCancelRequest cancelRequest = KakaoPayCancelRequest.builder()
+                .cid(cid)
+                .tid(order.getTid())
+                .cancelAmount(String.valueOf(order.getTotalPrice()))
+                .cancelTaxFreeAmount("0")
+                .build();
+
+        HttpEntity<KakaoPayCancelRequest> entityMap = new HttpEntity<>(cancelRequest, headers);
+
+        try {
+            new RestTemplate().postForEntity(
+                    "https://open-api.kakaopay.com/online/v1/payment/cancel",
+                    entityMap,
+                    CancelResponseDto.class
+            );
+
+            return true;
+        } catch (HttpStatusCodeException ex) {
+            log.error("카카오페이 결제 취소 실패: Status code: {}, Response body: {}", ex.getStatusCode(), ex.getResponseBodyAsString());
+            return false;
+        }
+    }
+
+    public String checkStatus(Order order) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "SECRET_KEY " + secretKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        KakaoPayCheckStatusRequest request = KakaoPayCheckStatusRequest.builder()
+                .cid(cid)
+                .tid(order.getTid())
+                .build();
+
+        HttpEntity<KakaoPayCheckStatusRequest> entityMap = new HttpEntity<>(request, headers);
+
+        try {
+            ResponseEntity<KakaoPayCheckStatusResponse> response = new RestTemplate().postForEntity(
+                    "https://open-api.kakaopay.com/online/v1/payment/order",
+                    entityMap,
+                    KakaoPayCheckStatusResponse.class
+            );
+
+            return response.getBody().getStatus();
+        } catch (HttpStatusCodeException ex) {
+            log.error("카카오페이 결제 상태 조회 실패");
+            return null;
+        }
+    }
+
+    private String generateOrderNumber() {
+        Random random = new Random();
+        String orderNum;
+        do {
+            String dateStr = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyMMdd"));
+            int randomNum = 10000 + random.nextInt(90000);
+            orderNum = dateStr + randomNum;
+        } while (ordersRepository.existsByOrderNum(orderNum)); // 중복 체크
+
+        return orderNum;
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/payment/service/KakaoPayService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/payment/service/KakaoPayService.java
@@ -1,13 +1,9 @@
 package dutchiepay.backend.global.payment.service;
 
-import dutchiepay.backend.domain.commerce.repository.BuyRepository;
 import dutchiepay.backend.domain.order.exception.OrderErrorCode;
 import dutchiepay.backend.domain.order.exception.OrderErrorException;
 import dutchiepay.backend.domain.order.repository.OrderRepository;
-import dutchiepay.backend.domain.order.repository.ProductRepository;
-import dutchiepay.backend.entity.Buy;
 import dutchiepay.backend.entity.Order;
-import dutchiepay.backend.entity.Product;
 import dutchiepay.backend.entity.User;
 import dutchiepay.backend.global.payment.dto.kakao.*;
 import dutchiepay.backend.global.payment.exception.PaymentErrorCode;
@@ -15,229 +11,93 @@ import dutchiepay.backend.global.payment.exception.PaymentErrorException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.HttpStatusCodeException;
-import org.springframework.web.client.RestTemplate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Random;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class KakaoPayService {
 
-    private final ProductRepository productRepository;
-    private final BuyRepository buyRepository;
     private final OrderRepository ordersRepository;
-    @Value("${host.backend}")
-    private String backendHost;
+    private final KakaoPayRequestService kakaoPayRequestService;
 
     @Value("${host.frontend}")
     private String frontendHost;
 
-    @Value("${payment.kakao.cid}")
-    private String cid;
-
-    @Value("${payment.kakao.secret}")
-    private String secretKey;
-
-    // 카카오페이 결제를 시작하기 위해 결제정보를 카카오페이 서버에 전달하고 결제 고유번호(TID)와 URL을 응답받는 단계
-    @Transactional
-    public KakaoPayReadyResponseDto kakaoPayReady(User user, ReadyRequestDto req) {
-        Buy buy = buyRepository.findById(req.getBuyId())
-                .orElseThrow(() -> new PaymentErrorException(PaymentErrorCode.INVALID_BUY));
-
-        Order newOrder = Order.builder()
-                .user(user)
-                .product(buy.getProduct())
-                .buy(buy)
-                .receiver(req.getReceiver())
-                .phone(req.getPhone())
-                .zipCode(req.getZipCode())
-                .address(req.getAddress())
-                .detail(req.getDetail())
-                .message(req.getMessage())
-                .totalPrice(req.getTotalAmount())
-                .payment("kakao")
-                .orderedAt(LocalDateTime.now())
-                .state("주문완료")
-                .quantity(req.getQuantity())
-                .orderNum(generateOrderNumber())
-                .build();
-
-        ordersRepository.save(newOrder);
-
-        HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.add("Authorization", "SECRET_KEY " + secretKey);
-        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
-
-        KakaoPayReadyRequest body = KakaoPayReadyRequest.builder()
-                .cid(cid) // 가맹점 코드(테스트용은 TC0ONETIME)
-                .partnerOrderId(newOrder.getOrderNum()) // 가맹점 주문번호
-                .partnerUserId(user.getNickname()) // 회원 id
-                .itemName(req.getProductName()) // 상품명
-                .quantity(req.getQuantity()) // 수량
-                .totalAmount(req.getTotalAmount()) // 상품 총액
-                .taxFreeAmount(req.getTaxFreeAmount()) // 비과세 금액
-                .approvalUrl(backendHost + "/pay/kakao/approve?orderNum=" + newOrder.getOrderNum()) // 결제 성공시 redirect url
-                .cancelUrl(backendHost + "/pay/kakao/cancel?orderNum=" + newOrder.getOrderNum()) // 결제 취소시 redirect url
-                .failUrl(backendHost + "/pay/kakao/fail?orderNum=" + newOrder.getOrderNum()) // 결제 실패시 redirect url
-                .build();
-
-        HttpEntity<KakaoPayReadyRequest> requestEntity = new HttpEntity<>(body, httpHeaders);
-        ResponseEntity<ReadyResponseDto> response = new RestTemplate().postForEntity(
-                "https://open-api.kakaopay.com/online/v1/payment/ready",
-                requestEntity,
-                ReadyResponseDto.class
-        );
-
-        ReadyResponseDto readyResponse = response.getBody();
-
-        newOrder.readyPurchase(readyResponse.getTid());
-
-        return KakaoPayReadyResponseDto.from(readyResponse.getNext_redirect_pc_url());
+    public KakaoPayReadyResponseDto kakaoPayReady(User user, ReadyRequestDto dto) {
+        return kakaoPayRequestService.ready(user, dto);
     }
 
-    // 사용자가 결제 수단을 선택하고 비밀번호를 입력해 결제 인증을 완료한 뒤, 최종적으로 결제 완료 처리를 하는 단계입니다.
-    // 인증완료 시 응답받은 pg_token과 tid로 최종 승인요청합니다.
-    // 결제 승인 API를 호출하면 결제 준비 단계에서 시작된 결제 건이 승인으로 완료 처리됩니다.
-    // 결제 승인 요청이 실패하면 카드사 등 결제 수단의 실패 정보가 필요에 따라 포함될 수 있습니다.
     @Transactional
     public ApproveResponseDto kakaoPayApprove(String pgToken, String orderNum) {
         Order order = ordersRepository.findByOrderNum(orderNum)
                 .orElseThrow(() -> new OrderErrorException(OrderErrorCode.INVALID_ORDER));
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "SECRET_KEY " + secretKey);
-        headers.setContentType(MediaType.APPLICATION_JSON);
+        ApproveResponseDto response = kakaoPayRequestService.approve(pgToken, order);
 
-        KakaoPayApproveRequest approveRequest = KakaoPayApproveRequest.builder()
-                .cid(cid)
-                .tid(order.getTid())
-                .partnerOrderId(orderNum)
-                .partnerUserId(order.getUser().getNickname())
-                .pgToken(pgToken)
-                .build();
-
-        HttpEntity<KakaoPayApproveRequest> entityMap = new HttpEntity<>(approveRequest, headers);
-        try {
-            ResponseEntity<ApproveResponseDto> response = new RestTemplate().postForEntity(
-                    "https://open-api.kakaopay.com/online/v1/payment/approve",
-                    entityMap,
-                    ApproveResponseDto.class
-            );
-
-            order.changeStatus("공구진행중");
-            order.getBuy().upCount(order.getQuantity());
-
-            return response.getBody();
-        } catch (HttpStatusCodeException ex) {
-            return null;
+        if (response == null) {
+            throw new PaymentErrorException(PaymentErrorCode.INVALID_KAKAO_APPROVE_RESPONSE);
         }
-    }
 
-    public boolean cancelExchange(String orderNum, String orderState) {
-        Order order = ordersRepository.findByOrderNum(orderNum)
-                .orElseThrow(() -> new OrderErrorException(OrderErrorCode.INVALID_ORDER));
+        order.changeStatus("공구진행중");
+        order.getBuy().upCount(order.getQuantity());
 
-        String status = kakaPayCheckStatus(order);
-
-        if (status.equals("SUCCESS_PAYMENT")) {
-            kakaoPayCancel(order, orderState);
-            return true;
-        } else {
-            throw new PaymentErrorException(PaymentErrorCode.INVALID_KAKAO_CANCEL_STATUS);
-        }
+        return response;
     }
 
     @Transactional
-    public void kakaoPayCancel(Order order, String state) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "SECRET_KEY " + secretKey);
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
-        KakaoPayCancelRequest cancelRequest = KakaoPayCancelRequest.builder()
-                .cid(cid)
-                .tid(order.getTid())
-                .cancelAmount(String.valueOf(order.getTotalPrice()))
-                .cancelTaxFreeAmount("0")
-                .build();
-
-        HttpEntity<KakaoPayCancelRequest> entityMap = new HttpEntity<>(cancelRequest, headers);
-
-        try {
-            new RestTemplate().postForEntity(
-                    "https://open-api.kakaopay.com/online/v1/payment/cancel",
-                    entityMap,
-                    CancelResponseDto.class
-            );
-
-            order.changeStatus(state);
-        } catch (HttpStatusCodeException ex) {
-            log.error("카카오페이 결제 취소 실패: Status code: {}, Response body: {}", ex.getStatusCode(), ex.getResponseBodyAsString());
+    public boolean kakaoPayCancel(Order order, String state) {
+        if (!kakaoPayRequestService.cancel(order)) {
             throw new PaymentErrorException(PaymentErrorCode.ERROR_KAKAOPAY_CANCEL);
         }
+
+        order.changeStatus(state);
+        return true;
     }
 
-    public String kakaPayCheckStatus(String orderNum) {
+    @Transactional
+    public boolean kakaoPayCancel(String orderNum, String state) {
         Order order = ordersRepository.findByOrderNum(orderNum)
                 .orElseThrow(() -> new OrderErrorException(OrderErrorCode.INVALID_ORDER));
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "SECRET_KEY " + secretKey);
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
-        KakaoPayCheckStatusRequest request = KakaoPayCheckStatusRequest.builder()
-                .cid(cid)
-                .tid(order.getTid())
-                .build();
-
-        HttpEntity<KakaoPayCheckStatusRequest> entityMap = new HttpEntity<>(request, headers);
-
-        try {
-            ResponseEntity<KakaoPayCheckStatusResponse> response = new RestTemplate().postForEntity(
-                    "https://open-api.kakaopay.com/online/v1/payment/order",
-                    entityMap,
-                    KakaoPayCheckStatusResponse.class
-            );
-
-            return response.getBody().getStatus();
-        } catch (HttpStatusCodeException ex) {
-            log.error("카카오페이 결제 상태 조회 실패");
-            throw new PaymentErrorException(PaymentErrorCode.ERROR_KAKAOPAY_STATUS);
+        if (!kakaoPayRequestService.cancel(order)) {
+            throw new PaymentErrorException(PaymentErrorCode.ERROR_KAKAOPAY_CANCEL);
         }
+
+        order.changeStatus(state);
+        return true;
     }
 
-    public String kakaPayCheckStatus(Order order) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "SECRET_KEY " + secretKey);
-        headers.setContentType(MediaType.APPLICATION_JSON);
+    public String kakaoPayCheckStatus(Order order) {
+        String status = kakaoPayRequestService.checkStatus(order);
 
-        KakaoPayCheckStatusRequest request = KakaoPayCheckStatusRequest.builder()
-                .cid(cid)
-                .tid(order.getTid())
-                .build();
-
-        HttpEntity<KakaoPayCheckStatusRequest> entityMap = new HttpEntity<>(request, headers);
-
-        try {
-            ResponseEntity<KakaoPayCheckStatusResponse> response = new RestTemplate().postForEntity(
-                    "https://open-api.kakaopay.com/online/v1/payment/order",
-                    entityMap,
-                    KakaoPayCheckStatusResponse.class
-            );
-
-            return response.getBody().getStatus();
-        } catch (HttpStatusCodeException ex) {
-            log.error("카카오페이 결제 상태 조회 실패");
+        if (status == null) {
             throw new PaymentErrorException(PaymentErrorCode.ERROR_KAKAOPAY_STATUS);
         }
+
+        return status;
+    }
+
+    public String kakaoPayCheckStatus(String orderNum) {
+        Order order = ordersRepository.findByOrderNum(orderNum)
+                .orElseThrow(() -> new OrderErrorException(OrderErrorCode.INVALID_ORDER));
+
+        String status = kakaoPayRequestService.checkStatus(order);
+
+        if (status == null) {
+            throw new PaymentErrorException(PaymentErrorCode.ERROR_KAKAOPAY_STATUS);
+        }
+
+        return status;
+    }
+
+    @Transactional
+    public void kakaoPayFail(String orderNum) {
+        Order order = ordersRepository.findByOrderNum(orderNum)
+                .orElseThrow(() -> new OrderErrorException(OrderErrorCode.INVALID_ORDER));
+
+        order.changeStatus("결제실패");
     }
 
     public String makePostMessage(String orderNum, String paymentStatus) {
@@ -258,25 +118,5 @@ public class KakaoPayService {
                     orderNum,
                     frontendHost
             );
-    }
-
-    private String generateOrderNumber() {
-        Random random = new Random();
-        String orderNum;
-        do {
-            String dateStr = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyMMdd"));
-            int randomNum = 10000 + random.nextInt(90000);
-            orderNum = dateStr + randomNum;
-        } while (ordersRepository.existsByOrderNum(orderNum)); // 중복 체크
-
-        return orderNum;
-    }
-
-
-    public void kakaoPayFail(String orderNum) {
-        Order order = ordersRepository.findByOrderNum(orderNum)
-                .orElseThrow(() -> new OrderErrorException(OrderErrorCode.INVALID_ORDER));
-
-        order.changeStatus("결제실패");
     }
 }


### PR DESCRIPTION
### ⚡이슈 번호
resolve #140,139

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 관심사 로직 분리
<img width="702" alt="스크린샷 2024-11-22 오후 4 49 28" src="https://github.com/user-attachments/assets/06952138-531d-420b-93b4-65e3a6d88f21">

현재 하나의 서비스 로직 안에서 cancelExchange 메소드가 kakaoPayCancel 메소드를 사용하고 있습니다.
하지만 이러한 경우에 this 로 직접 호출하게 되는데 이렇게 될 경우 트랜잭션 처리가 제대로 되지 않는 현상이 존재합니다.(Spring AOP 동작 방식 문제로 인해, this로 직접 호출하게 되면 프록시 처리가 되지 않기 때문이라고 합니다.)

따라서, 해결하기 위해서는 KakaoPayService 자기 자신을 직접 의존성 주입하여 사용하여야 하는데, 이러한 방법보다는 카카오페이 서버에 요청을 보내는 로직과 사용자 서비스를 처리하는 로직을 분리하여 해결하는 방법을 선택하였습니다

- 공구실패/환불 시 nowCount 가 감소하는 부분을 하나로 합쳤습니다.
<img width="746" alt="스크린샷 2024-11-22 오후 4 56 09" src="https://github.com/user-attachments/assets/9eef2c40-b5b5-40bd-afb6-d48cc6876565">
<img width="707" alt="스크린샷 2024-11-22 오후 4 56 29" src="https://github.com/user-attachments/assets/a4f85629-aa69-44e4-b983-c6323851f5bb">

- buy.disCount() 로직에서 음수값이 되지 않도록 count >= this.nowCount 의 경우 0으로 변경하도록 하였습니다.
하지만, 이 경우 에러가 발생함에도 제대로 처리가 되지 않을 수 있기 때문에 어떠한 방법이 좋을 지 말씀해주시면 감사하겠습니다.
<img width="738" alt="스크린샷 2024-11-22 오후 4 56 45" src="https://github.com/user-attachments/assets/f1181280-9590-4118-bfef-cf1d6177d8d1">


- 스케쥴러 코드에서 날짜를 비교함에 있어 잘못되어 있는 부분(>=, <) 을 발견 한 후 조건에 맞추기 위해 변경하였습니다.
<img width="746" alt="스크린샷 2024-11-22 오후 4 57 01" src="https://github.com/user-attachments/assets/ac626836-3d88-43d4-9535-1c343f07de2e">

---
### 📖 참고 사항
- 현지님께서 노션에 올려주신 공구가 성공하였음에도 실패하는 경우를 테스트해보지 못했습니다. 추후 배포 서버에서 테스트를 진행해보고나서 다시 확인해봐야 할 것 같습니다.
