### PR TITLE
구매내역 조회 시 배송 메시지 반환안되는 문제 / 최대 구매 수량 99개 제한 / 구매 목록 API에 더 이상 반환할 상품 없을 경우 특정 값으로 안내

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/MyGoodsResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/MyGoodsResponseDto.java
@@ -3,29 +3,39 @@ package dutchiepay.backend.domain.profile.dto;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MyGoodsResponseDto {
-    private Long orderId;
-    private String orderNum;
-    private Long buyId;
-    private LocalDate orderDate;
-    private String productName;
-    private Integer quantity;
-    private Integer productPrice;
-    private Integer discountPrice;
-    private Integer totalPrice;
-    private String payment;
-    private String receiver;
-    private String address;
-    private String zipCode;
-    private String detail;
-    private String phone;
-    private String deliveryState;
-    private String productImg;
-    private String storeName;
-    private String message;
+    private List<Goods> goods;
+    private Boolean hasNext;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Goods {
+        private Long orderId;
+        private String orderNum;
+        private Long buyId;
+        private LocalDate orderDate;
+        private String productName;
+        private Integer quantity;
+        private Integer productPrice;
+        private Integer discountPrice;
+        private Integer totalPrice;
+        private String payment;
+        private String receiver;
+        private String address;
+        private String zipCode;
+        private String detail;
+        private String phone;
+        private String deliveryState;
+        private String productImg;
+        private String storeName;
+        private String message;
+    }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface QProfileRepository {
     List<GetMyLikesResponseDto> getMyLike(User user);
 
-    List<MyGoodsResponseDto> getMyGoods(User user, String filter, Pageable pageable);
+    MyGoodsResponseDto getMyGoods(User user, String filter, Pageable pageable);
 
     List<MyPostsResponseDto> getMyPosts(User user, PageRequest pageable);
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
@@ -176,6 +176,7 @@ public class QProfileRepositoryImpl implements QProfileRepository {
                         orders.zipCode,
                         orders.detail,
                         orders.state,
+                        orders.message,
                         product.productImg,
                         store.storeName)
                 .from(orders)

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
@@ -157,7 +157,7 @@ public class QProfileRepositoryImpl implements QProfileRepository {
     }
 
     @Override
-    public List<MyGoodsResponseDto> getMyGoods(User user, String filter, Pageable pageable) {
+    public MyGoodsResponseDto getMyGoods(User user, String filter, Pageable pageable) {
         BooleanExpression filterCondition = getMyGoodsFilterCondition(filter);
 
         List<Tuple> tuple =  jpaQueryFactory
@@ -185,10 +185,17 @@ public class QProfileRepositoryImpl implements QProfileRepository {
                 .where(orders.user.eq(user), filterCondition)
                 .orderBy(orders.orderedAt.desc())
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .limit(pageable.getPageSize() + 1)
                 .fetch();
 
-        List<MyGoodsResponseDto> result = new ArrayList<>();
+        boolean hasNext = false;
+        List<Tuple> content = tuple;
+        if (tuple.size() > pageable.getPageSize()) {
+            hasNext = true;
+            content = tuple.subList(0, pageable.getPageSize());
+        }
+
+        List<MyGoodsResponseDto.Goods> result = new ArrayList<>();
 
         if (pageable.getPageNumber() == 0 && tuple.isEmpty()) {
             throw new ProfileErrorException(ProfileErrorCode.NO_HISTORY_ORDER);
@@ -197,8 +204,8 @@ public class QProfileRepositoryImpl implements QProfileRepository {
         }
 
 
-        for (Tuple t : tuple) {
-            MyGoodsResponseDto dto = MyGoodsResponseDto.builder()
+        for (Tuple t : content) {
+            MyGoodsResponseDto.Goods dto = MyGoodsResponseDto.Goods.builder()
                     .orderId(t.get(orders.orderId))
                     .orderNum(t.get(orders.orderNum))
                     .buyId(t.get(buy.buyId))
@@ -222,7 +229,10 @@ public class QProfileRepositoryImpl implements QProfileRepository {
             result.add(dto);
         }
 
-        return result;
+        return MyGoodsResponseDto.builder()
+                .goods(result)
+                .hasNext(hasNext)
+                .build();
     }
 
     private BooleanExpression getMyGoodsFilterCondition(String filter) {

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
@@ -36,7 +36,7 @@ public class ProfileService {
         return MyPageResponseDto.from(user);
     }
 
-    public List<MyGoodsResponseDto> getMyGoods(User user, Long page, Long limit, String filter) {
+    public MyGoodsResponseDto getMyGoods(User user, Long page, Long limit, String filter) {
         if (filter != null && !(filter.equals("pending") || filter.equals("shipped") || filter.equals("delivered"))) {
                 throw new ProfileErrorException(ProfileErrorCode.INVALID_ORDER_STATUS);
             }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/payment/controller/PaymentController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/payment/controller/PaymentController.java
@@ -8,6 +8,7 @@ import dutchiepay.backend.global.payment.service.KakaoPayService;
 import dutchiepay.backend.global.payment.service.TossPaymentsService;
 import dutchiepay.backend.global.security.UserDetailsImpl;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
@@ -33,7 +34,7 @@ public class PaymentController {
     @PostMapping("/ready")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> ready(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                   @RequestBody ReadyRequestDto req,
+                                   @Valid @RequestBody ReadyRequestDto req,
                                    @RequestParam String type) {
         if (type.equals("kakao")) {
             return ResponseEntity.ok().body(kakaoPayService.kakaoPayReady(userDetails.getUser(), req));

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/payment/dto/kakao/ReadyRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/payment/dto/kakao/ReadyRequestDto.java
@@ -1,6 +1,7 @@
 package dutchiepay.backend.global.payment.dto.kakao;
 
 import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.*;
 
 @Getter
@@ -11,6 +12,7 @@ public class ReadyRequestDto {
     private Long buyId;
     private String productName;
     @Max(value = 99, message = "최대 수량은 99개까지 가능합니다.")
+    @Min(value = 1, message = "최소 수량은 1개 이상입니다.")
     private Integer quantity;
     private Integer totalAmount;
     private Integer taxFreeAmount;

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/payment/dto/kakao/ReadyRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/payment/dto/kakao/ReadyRequestDto.java
@@ -1,5 +1,6 @@
 package dutchiepay.backend.global.payment.dto.kakao;
 
+import jakarta.validation.constraints.Max;
 import lombok.*;
 
 @Getter
@@ -9,6 +10,7 @@ import lombok.*;
 public class ReadyRequestDto {
     private Long buyId;
     private String productName;
+    @Max(value = 99, message = "최대 수량은 99개까지 가능합니다.")
     private Integer quantity;
     private Integer totalAmount;
     private Integer taxFreeAmount;


### PR DESCRIPTION
### ⚡이슈 번호
resolve #

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 구매내역 조회 시 order.message 데이터를 가져오는 부분이 누락되어 있어서 추가하여 반환하도록 하였습니다.
- 카카오페이 결제 시 최대 구매 수량이 99개가 넘을 경우 validation 체크에서 검증하도록 하였습니다.(Max 어노테이션 사용)
- 구매목록 API에서 더 이상 반환할 상품이 존재하지 않다면 hasNext값이 false, 존재한다면 true를 반환하도록 하였습니다.
<img width="912" alt="스크린샷 2024-11-26 오후 4 31 34" src="https://github.com/user-attachments/assets/7d60d50d-213f-4a78-a380-2c36918436f6">

- 단순 개수만으로는 파악하기 힘들다고 생각하여, 다음 페이지까지 불러와 체크를 하였습니다(limit이 10인데 데이터가 10개라면 다음 데이터 존재여부를 정확히 파악할 수 없음)
- 또한 이에 맞춰 응답 dto 형태를 변경하였습니다(노션 응답 페이지 수정 완료)
---
### 📖 참고 사항
- 포트원 결제 서비스의 경우 프론트엔드 측에서 결제까지 진행하는 것이라고 전달받아서 서버에서 별도의 검증 로직을 넣지 않았습니다.
(결제 취소, 환불 등이 아닌 결제 자체가 되지 않게 하는 것이 현재 목표)