### PR TITLE
리뷰내역 조회 시 orderNum 반환, 리뷰 수정 시 이미지 빈 배열 받도록 변경

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/repository/QReviewRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/repository/QReviewRepositoryImpl.java
@@ -27,6 +27,7 @@ public class QReviewRepositoryImpl implements QReviewRepository {
                 .select(review.reviewId,
                         review.order.buy.buyId,
                         review.order.product.productName,
+                        review.order.orderNum,
                         review.rating,
                         review.contents,
                         review.createdAt,
@@ -54,6 +55,7 @@ public class QReviewRepositoryImpl implements QReviewRepository {
                     .reviewId(t.get(review.reviewId))
                     .buyId(t.get(review.order.buy.buyId))
                     .productName(t.get(review.order.product.productName))
+                    .orderNum(t.get(review.order.orderNum))
                     .rating(t.get(review.rating))
                     .content(t.get(review.contents))
                     .createdAt(createdAt)

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/GetMyReviewResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/GetMyReviewResponseDto.java
@@ -14,14 +14,14 @@ public class GetMyReviewResponseDto {
     private Long reviewId;
     private Long buyId;
     private String productName;
+    private String orderNum;
     private Integer rating;
     private String content;
     private LocalDate createdAt;
     private Boolean isPossible;
     private String[] reviewImg;
 
-
-    public static GetMyReviewResponseDto from(Review review) {
+    public static GetMyReviewResponseDto from(Review review, String orderNum) {
         LocalDate createdAt = review.getCreatedAt().toLocalDate();
         long daysBetween = ChronoUnit.DAYS.between(createdAt, LocalDate.now());
 
@@ -29,6 +29,7 @@ public class GetMyReviewResponseDto {
                 .reviewId(review.getReviewId())
                 .buyId(review.getOrder().getBuy().getBuyId())
                 .productName(review.getOrder().getProduct().getProductName())
+                .orderNum(orderNum)
                 .rating(review.getRating())
                 .content(review.getContents())
                 .createdAt(createdAt)

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
@@ -68,7 +68,7 @@ public class ProfileService {
         Review review = reviewRepository.findByUserAndReviewId(user, reviewId)
                 .orElseThrow(() -> new ProfileErrorException(ProfileErrorCode.INVALID_REVIEW));
 
-        return GetMyReviewResponseDto.from(review);
+        return GetMyReviewResponseDto.from(review, review.getOrder().getOrderNum());
     }
 
 
@@ -220,7 +220,7 @@ public class ProfileService {
             throw new ReviewErrorException(ReviewErrorCode.CANNOT_UPDATE_CAUSE_COUNT);
         } else {
             String reviewImg = null;
-            if (req.getReviewImg() != null) {
+            if (req.getReviewImg() != null && req.getReviewImg().length > 0) {
                 for (String img : req.getReviewImg()) {
                     sb.append(img).append(",");
                 }


### PR DESCRIPTION
### ⚡이슈 번호
resolve #147 

---
### ✅ PR 종류
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 리뷰내역 조회 시 orderNum이 필요하다고 하여 이를 반환하도록 응답 dto와 쿼리를 수정하였습니다.
- 이미지 수정 시 req.getReviewImg가 빈 배열인 경우 null은 아니기 때문에 length가 0보다 큰지 체크 하는 부분을 추가하였습니다.
---
### 📖 참고 사항
