### PR TITLE
리뷰 수정, 삭제 시 score 데이터 변경 / 리뷰,스코어 서비스 관심사 분리

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/image/controller/ImageController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/image/controller/ImageController.java
@@ -1,7 +1,7 @@
 package dutchiepay.backend.domain.image.controller;
 
 import dutchiepay.backend.domain.image.dto.GetPreSignedUrlRequestDto;
-import dutchiepay.backend.domain.image.service.ImageService;
+import dutchiepay.backend.domain.image.service.S3ImageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -17,11 +17,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/image")
 @RequiredArgsConstructor
 public class ImageController {
-    private final ImageService imageService;
+    private final S3ImageService s3ImageService;
 
     @Operation(summary = "이미지 업로드(구현 완료)", description = "파일 명을 바탕으로 한 presigned url을 반환.(유효기간 15분)")
     @PostMapping
     public ResponseEntity<?> getPreSignedUrl(@Valid @RequestBody GetPreSignedUrlRequestDto request) {
-        return ResponseEntity.ok().body(imageService.getPreSignedUrl(request.getFileName()));
+        return ResponseEntity.ok().body(s3ImageService.getPreSignedUrl(request.getFileName()));
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/image/service/ImageService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/image/service/ImageService.java
@@ -1,75 +1,21 @@
 package dutchiepay.backend.domain.image.service;
 
-import com.amazonaws.HttpMethod;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.Headers;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
-import dutchiepay.backend.domain.image.dto.GetPreSignedUrlResponseDto;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.net.URL;
-import java.util.Date;
-
 @Service
-@RequiredArgsConstructor
-@Slf4j
 public class ImageService {
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
+    public String processImages(String[] reviewImages) {
+        if (reviewImages == null || reviewImages.length == 0) {
+            return null;
+        }
 
-    private final AmazonS3 amazonS3;
-
-    /**
-     * presigned url 발급
-     * @author     dnjsals45
-     * @version    1.0.0
-     * @since      1.0.0
-     * @param      fileName 파일명
-     * @return     GetPreSignedUrlResponseDto(presigned url)
-     */
-    public GetPreSignedUrlResponseDto getPreSignedUrl(String fileName) {
-        GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePresignedUrlRequest(bucket, fileName);
-        URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
-
-        return GetPreSignedUrlResponseDto.builder()
-                .uploadUrl(url.toString())
-                .build();
-    }
-
-    /**
-     * 파일 업로드용(POST) presigned url 발급
-     * @author     dnjsals45
-     * @version    1.0.0
-     * @since      1.0.0
-     * @param      bucket 버킷명
-     * @param      fileName 파일명
-     * @return     GeneratePresignedUrlRequest
-     */
-    private GeneratePresignedUrlRequest getGeneratePresignedUrlRequest(String bucket, String fileName) {
-       GeneratePresignedUrlRequest generatePresignedUrlRequest =
-               new GeneratePresignedUrlRequest(bucket, fileName)
-                       .withMethod(HttpMethod.PUT)
-                       .withExpiration(getPresignedUrlExpiration());
-       generatePresignedUrlRequest.addRequestParameter(Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
-       return generatePresignedUrlRequest;
-    }
-
-    /**
-     * presigned url 만료시간 설정(15분)
-     * @author     dnjsals45
-     * @version    1.0.0
-     * @since      1.0.0
-     * @return     presigned url 만료시간
-     */
-    private Date getPresignedUrlExpiration() {
-        Date expiration = new Date();
-        long expTimeMillis = expiration.getTime();
-        expTimeMillis += 1000 * 60 * 15;
-        expiration.setTime(expTimeMillis);
-        return expiration;
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < reviewImages.length; i++) {
+            sb.append(reviewImages[i]);
+            if (i < reviewImages.length - 1) {
+                sb.append(",");
+            }
+        }
+        return sb.toString();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/image/service/S3ImageService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/image/service/S3ImageService.java
@@ -1,0 +1,75 @@
+package dutchiepay.backend.domain.image.service;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import dutchiepay.backend.domain.image.dto.GetPreSignedUrlResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.net.URL;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3ImageService {
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3 amazonS3;
+
+    /**
+     * presigned url 발급
+     * @author     dnjsals45
+     * @version    1.0.0
+     * @since      1.0.0
+     * @param      fileName 파일명
+     * @return     GetPreSignedUrlResponseDto(presigned url)
+     */
+    public GetPreSignedUrlResponseDto getPreSignedUrl(String fileName) {
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePresignedUrlRequest(bucket, fileName);
+        URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
+
+        return GetPreSignedUrlResponseDto.builder()
+                .uploadUrl(url.toString())
+                .build();
+    }
+
+    /**
+     * 파일 업로드용(POST) presigned url 발급
+     * @author     dnjsals45
+     * @version    1.0.0
+     * @since      1.0.0
+     * @param      bucket 버킷명
+     * @param      fileName 파일명
+     * @return     GeneratePresignedUrlRequest
+     */
+    private GeneratePresignedUrlRequest getGeneratePresignedUrlRequest(String bucket, String fileName) {
+       GeneratePresignedUrlRequest generatePresignedUrlRequest =
+               new GeneratePresignedUrlRequest(bucket, fileName)
+                       .withMethod(HttpMethod.PUT)
+                       .withExpiration(getPresignedUrlExpiration());
+       generatePresignedUrlRequest.addRequestParameter(Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
+       return generatePresignedUrlRequest;
+    }
+
+    /**
+     * presigned url 만료시간 설정(15분)
+     * @author     dnjsals45
+     * @version    1.0.0
+     * @since      1.0.0
+     * @return     presigned url 만료시간
+     */
+    private Date getPresignedUrlExpiration() {
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += 1000 * 60 * 15;
+        expiration.setTime(expTimeMillis);
+        return expiration;
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/exception/ReviewErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/exception/ReviewErrorCode.java
@@ -12,12 +12,16 @@ public enum ReviewErrorCode implements StatusCode {
     /**
      * 400 BAD_REQUEST
      */
-
     ALREADY_EXIST(HttpStatus.BAD_REQUEST, "작성한 상품 리뷰가 이미 존재합니다."),
     INVALID_REVIEW(HttpStatus.BAD_REQUEST, "존재하지 않는 리뷰입니다."),
     CANNOT_UPDATE_CAUSE_30DAYS(HttpStatus.BAD_REQUEST, "리뷰 작성 후 30일이 지나 수정할 수 없습니다."),
     CANNOT_UPDATE_CAUSE_COUNT(HttpStatus.BAD_REQUEST, "리뷰 수정은 2회까지만 가능합니다."),
-    INVALID_RATING(HttpStatus.BAD_REQUEST, "올바르지 않은 평점입니다."),;
+    INVALID_RATING(HttpStatus.BAD_REQUEST, "올바르지 않은 평점입니다."),
+
+    /**
+     * 403 FORBIDDEN
+     */
+    REVIEW_USER_MISS_MATCH(HttpStatus.FORBIDDEN, "본인이 작성한 후기가 아닙니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/repository/ReviewRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/repository/ReviewRepository.java
@@ -11,15 +11,11 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long>, QReviewRepository {
-    List<Review> findAllByUser(User user);
-
     Optional<Review> findByUserAndReviewId(User user, Long reviewId);
 
     @Modifying
     @Query("update Review r set r.deletedAt = current_timestamp where r = ?1")
     void softDelete(Review review);
-
-    boolean existsByUserAndOrder(User user, Order order);
 
     boolean existsByUserAndOrderAndDeletedAtIsNull(User user, Order order);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderUtilService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/order/service/OrderUtilService.java
@@ -1,0 +1,19 @@
+package dutchiepay.backend.domain.order.service;
+
+import dutchiepay.backend.domain.order.exception.OrderErrorCode;
+import dutchiepay.backend.domain.order.exception.OrderErrorException;
+import dutchiepay.backend.domain.order.repository.OrderRepository;
+import dutchiepay.backend.entity.Order;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderUtilService {
+    private final OrderRepository orderRepository;
+
+    public Order findById(Long orderId) {
+        return orderRepository.findById(orderId)
+                .orElseThrow(() -> new OrderErrorException(OrderErrorCode.INVALID_ORDER));
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/controller/ProfileController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/controller/ProfileController.java
@@ -2,6 +2,7 @@ package dutchiepay.backend.domain.profile.controller;
 
 import dutchiepay.backend.domain.profile.dto.*;
 import dutchiepay.backend.domain.profile.service.ProfileService;
+import dutchiepay.backend.domain.profile.service.ReviewService;
 import dutchiepay.backend.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,8 +18,8 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/profile")
 public class ProfileController {
-
     private final ProfileService profileService;
+    private final ReviewService reviewService;
 
     /**
      * GET
@@ -62,7 +63,7 @@ public class ProfileController {
     @GetMapping("/reviews")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> myReviews(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return ResponseEntity.ok().body(profileService.getMyReviews(userDetails.getUser()));
+        return ResponseEntity.ok().body(reviewService.getMyReviews(userDetails.getUser()));
     }
 
     @Operation(summary = "후기 1개 조회 (구현 완료)", description = "reviewId 입력하지 않을 시 내가 쓴 후기 전체 조회")
@@ -70,7 +71,7 @@ public class ProfileController {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getOneReview(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                          @RequestParam(name = "reviewId", required = false) Long reviewId) {
-        return ResponseEntity.ok().body(profileService.getOneReview(userDetails.getUser(), reviewId));
+        return ResponseEntity.ok().body(reviewService.getOneReview(userDetails.getUser(), reviewId));
     }
 
     @Operation(summary = "내가 쓴 문의 내역 조회 (구현 완료)")
@@ -89,7 +90,7 @@ public class ProfileController {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> createReview(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                           @Valid @RequestBody CreateReviewRequestDto req) {
-        profileService.createReview(userDetails.getUser(), req);
+        reviewService.createReview(userDetails.getUser(), req);
         return ResponseEntity.ok().build();
     }
 
@@ -146,7 +147,7 @@ public class ProfileController {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> updateReview(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                           @Valid @RequestBody UpdateReviewRequestDto request) {
-        profileService.updateReview(userDetails.getUser(), request);
+        reviewService.updateReview(userDetails.getUser(), request);
         return ResponseEntity.ok().build();
     }
 
@@ -158,7 +159,7 @@ public class ProfileController {
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> deleteReview(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                        @RequestParam(name = "reviewId") Long reviewId) {
-        profileService.deleteReview(userDetails.getUser(), reviewId);
+        reviewService.deleteReview(userDetails.getUser(), reviewId);
         return ResponseEntity.ok().build();
     }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ProfileService.java
@@ -199,7 +199,14 @@ public class ProfileService {
             throw new ProfileErrorException(ProfileErrorCode.DELETE_REVIEW_USER_MISSMATCH);
         }
 
+        int deleteRating = review.getRating();
+
         reviewRepository.softDelete(review);
+
+        Score score = scoreRepository.findByBuy(review.getOrder().getBuy());
+        if (score != null) {
+            score.removeReview(deleteRating);
+        }
     }
 
     @Transactional
@@ -219,6 +226,9 @@ public class ProfileService {
         } else if (review.getUpdateCount() == 2) {
             throw new ReviewErrorException(ReviewErrorCode.CANNOT_UPDATE_CAUSE_COUNT);
         } else {
+            int oldRating = review.getRating();
+            int newRating = req.getRating();
+
             String reviewImg = null;
             if (req.getReviewImg() != null && req.getReviewImg().length > 0) {
                 for (String img : req.getReviewImg()) {
@@ -228,6 +238,11 @@ public class ProfileService {
             }
 
             review.update(req.getContent(), req.getRating(), reviewImg);
+
+            Score score = scoreRepository.findByBuy(review.getOrder().getBuy());
+            if (score != null) {
+                score.updateReview(oldRating, newRating);
+            }
         }
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ReviewService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ReviewService.java
@@ -1,0 +1,82 @@
+package dutchiepay.backend.domain.profile.service;
+
+import dutchiepay.backend.domain.image.service.ImageService;
+import dutchiepay.backend.domain.profile.dto.CreateReviewRequestDto;
+import dutchiepay.backend.domain.profile.dto.GetMyReviewResponseDto;
+import dutchiepay.backend.domain.profile.dto.UpdateReviewRequestDto;
+import dutchiepay.backend.entity.Order;
+import dutchiepay.backend.entity.Review;
+import dutchiepay.backend.entity.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+    private final ReviewValidator reviewValidator;
+    private final ImageService imageService;
+    private final ScoreService scoreService;
+    private final ReviewUtilService reviewUtilService;
+
+    @Transactional
+    public void createReview(User user, CreateReviewRequestDto req) {
+        Order order = reviewValidator.validateReviewCreation(user, req);
+
+        String reviewImg = imageService.processImages(req.getReviewImg());
+
+        createReviewEntity(user, order, req, reviewImg);
+
+        scoreService.updateScore(order, req.getRating());
+    }
+
+    @Transactional
+    public void updateReview(User user, UpdateReviewRequestDto req) {
+        Review review = reviewValidator.validateReviewUpdate(user, req);
+
+        int oldRating = review.getRating();
+        int newRating = req.getRating();
+
+        String reviewImg = imageService.processImages(req.getReviewImg());
+
+        review.update(req.getContent(), req.getRating(), reviewImg);
+
+        scoreService.updateScoreOnUpdate(review, oldRating, newRating);
+    }
+
+    @Transactional
+    public void deleteReview(User user, Long reviewId) {
+        Review review = reviewValidator.validateReviewDeletion(user, reviewId);
+
+        int deleteRating = review.getRating();
+
+        reviewUtilService.softDelete(review);
+
+        scoreService.updateScoreOnDelete(review, deleteRating);
+    }
+
+    public GetMyReviewResponseDto getOneReview(User user, Long reviewId) {
+        Review review = reviewUtilService.findByUserAndReviewId(user, reviewId);
+
+        return GetMyReviewResponseDto.from(review, review.getOrder().getOrderNum());
+    }
+
+    public List<GetMyReviewResponseDto> getMyReviews(User user) {
+        return reviewUtilService.getMyReviews(user);
+    }
+
+    private void createReviewEntity(User user, Order order, CreateReviewRequestDto req, String reviewImg) {
+        Review newReview = Review.builder()
+                            .user(user)
+                            .order(order)
+                            .contents(req.getContent())
+                            .rating(req.getRating())
+                            .reviewImg(reviewImg)
+                            .updateCount(0)
+                            .build();
+
+        reviewUtilService.save(newReview);
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ReviewUtilService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ReviewUtilService.java
@@ -1,0 +1,45 @@
+package dutchiepay.backend.domain.profile.service;
+
+import dutchiepay.backend.domain.order.exception.ReviewErrorCode;
+import dutchiepay.backend.domain.order.exception.ReviewErrorException;
+import dutchiepay.backend.domain.order.repository.ReviewRepository;
+import dutchiepay.backend.domain.profile.dto.GetMyReviewResponseDto;
+import dutchiepay.backend.entity.Order;
+import dutchiepay.backend.entity.Review;
+import dutchiepay.backend.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewUtilService {
+    private final ReviewRepository reviewRepository;
+
+    public Review findById(Long reviewId) {
+        return reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new ReviewErrorException(ReviewErrorCode.INVALID_REVIEW));
+    }
+
+    public Review save(Review review) {
+        return reviewRepository.save(review);
+    }
+
+    public Review findByUserAndReviewId(User user, Long reviewId) {
+        return reviewRepository.findByUserAndReviewId(user, reviewId)
+                .orElseThrow(() -> new ReviewErrorException(ReviewErrorCode.INVALID_REVIEW));
+    }
+
+    public void softDelete(Review review) {
+        reviewRepository.softDelete(review);
+    }
+
+    public boolean existsByUserAndOrderAndDeletedAtIsNull(User user, Order order) {
+        return reviewRepository.existsByUserAndOrderAndDeletedAtIsNull(user, order);
+    }
+
+    public List<GetMyReviewResponseDto> getMyReviews(User user) {
+        return reviewRepository.getMyReviews(user);
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ReviewValidator.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ReviewValidator.java
@@ -1,0 +1,84 @@
+package dutchiepay.backend.domain.profile.service;
+
+import dutchiepay.backend.domain.order.exception.ReviewErrorCode;
+import dutchiepay.backend.domain.order.exception.ReviewErrorException;
+import dutchiepay.backend.domain.order.service.OrderUtilService;
+import dutchiepay.backend.domain.profile.dto.CreateReviewRequestDto;
+import dutchiepay.backend.domain.profile.dto.UpdateReviewRequestDto;
+import dutchiepay.backend.domain.profile.exception.ProfileErrorCode;
+import dutchiepay.backend.domain.profile.exception.ProfileErrorException;
+import dutchiepay.backend.entity.Order;
+import dutchiepay.backend.entity.Review;
+import dutchiepay.backend.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewValidator {
+    private final ReviewUtilService reviewUtilService;
+    private final OrderUtilService orderUtilService;
+
+    public Order validateReviewCreation(User user, CreateReviewRequestDto req) {
+        validateRating(req.getRating());
+        Order order = orderUtilService.findById(req.getOrderId());
+        validateUserOrder(user, order);
+        validateReviewDuplication(user, order);
+        return order;
+    }
+
+    public Review validateReviewUpdate(User user, UpdateReviewRequestDto req) {
+        Review review = reviewUtilService.findById(req.getReviewId());
+
+        validateUserReview(user, review);
+        validateUpdateCondition(review);
+
+        return review;
+    }
+
+    public Review validateReviewDeletion(User user, Long reviewId) {
+        Review review = reviewUtilService.findById(reviewId);
+
+        validateUserReview(user, review);
+        return review;
+    }
+
+    private void validateUserReview(User user, Review review) {
+        if (!review.getUser().getUserId().equals(user.getUserId())) {
+            throw new ReviewErrorException(ReviewErrorCode.REVIEW_USER_MISS_MATCH);
+        }
+    }
+
+    private void validateReviewDuplication(User user, Order order) {
+        if (reviewUtilService.existsByUserAndOrderAndDeletedAtIsNull(user, order)) {
+            throw new ReviewErrorException(ReviewErrorCode.ALREADY_EXIST);
+        }
+    }
+
+    private void validateUserOrder(User user, Order order) {
+        if (!order.getUser().getUserId().equals(user.getUserId())) {
+            throw new ProfileErrorException(ProfileErrorCode.INVALID_USER_ORDER_REVIEW);
+        }
+    }
+
+    private void validateRating(Integer rating) {
+        if (rating < 1 || rating > 5) {
+            throw new ReviewErrorException(ReviewErrorCode.INVALID_RATING);
+        }
+    }
+
+    private void validateUpdateCondition(Review review) {
+        long dayBetween = ChronoUnit.DAYS.between(review.getCreatedAt().toLocalDate(), LocalDate.now());
+
+        if (dayBetween > 30) {
+            throw new ReviewErrorException(ReviewErrorCode.CANNOT_UPDATE_CAUSE_30DAYS);
+        }
+
+        if (review.getUpdateCount() == 2) {
+            throw new ReviewErrorException(ReviewErrorCode.CANNOT_UPDATE_CAUSE_COUNT);
+        }
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ScoreService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/service/ScoreService.java
@@ -1,0 +1,51 @@
+package dutchiepay.backend.domain.profile.service;
+
+import dutchiepay.backend.domain.commerce.repository.ScoreRepository;
+import dutchiepay.backend.entity.Order;
+import dutchiepay.backend.entity.Review;
+import dutchiepay.backend.entity.Score;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ScoreService {
+    private final ScoreRepository scoreRepository;
+
+    public void updateScore(Order order, int rating) {
+        Score score = scoreRepository.findByBuy(order.getBuy());
+        if (score == null) {
+            createNewScore(order, rating);
+        } else {
+            score.addReview(rating);
+        }
+    }
+
+    public void updateScoreOnUpdate(Review review, int oldRating, int newRating) {
+        Score score = scoreRepository.findByBuy(review.getOrder().getBuy());
+        if (score != null) {
+            score.updateReview(oldRating, newRating);
+        }
+    }
+
+    public void updateScoreOnDelete(Review review, int deleteRating) {
+        Score score = scoreRepository.findByBuy(review.getOrder().getBuy());
+        if (score != null) {
+            score.removeReview(deleteRating);
+        }
+    }
+
+    private void createNewScore(Order order, int rating) {
+        Score newScore = Score.builder()
+                .buy(order.getBuy())
+                .one(rating == 1 ? 1 : 0)
+                .two(rating == 2 ? 1 : 0)
+                .three(rating == 3 ? 1 : 0)
+                .four(rating == 4 ? 1 : 0)
+                .five(rating == 5 ? 1 : 0)
+                .count(1)
+                .build();
+
+        scoreRepository.save(newScore);
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Score.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Score.java
@@ -66,4 +66,31 @@ public class Score extends Auditing {
         }
         this.count++;
     }
+
+    public void removeReview(int rating) {
+        switch (rating) {
+            case 1:
+                this.one--;
+                break;
+            case 2:
+                this.two--;
+                break;
+            case 3:
+                this.three--;
+                break;
+            case 4:
+                this.four--;
+                break;
+            case 5:
+                this.five--;
+                break;
+            default:
+        }
+        this.count--;
+    }
+
+    public void updateReview(int oldRating, int newRating) {
+        removeReview(oldRating);
+        addReview(newRating);
+    }
 }


### PR DESCRIPTION
### ⚡이슈 번호
resolve #149 

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 리뷰 수정,삭제 시 score 데이터가 변경되지 않는 부분을 수정하였습니다.
- 리뷰 및 스코어 서비스가 ProfileService에 모두 포함되어 있던 부분을 분리하였습니다.
- SRP 원칙에 따라 클래스들을 생성하여 관심사를 분리하도록 하였습니다.
> ReviewService : 컨트롤러와 연결되어 리뷰와 관련된 서비스를 처리하는 서비스
> ReviewValidator : 리뷰 서비스 로직에서 유효성 검증 로직만 별도로 처리하는 컴포넌트
> ReviewUtilService : ReviewRepository와 연결되어 다른 서비스들에 repository 결과를 전달해주는 서비스 로직
> ScoreService : Score 엔티티와 관련되어 수정하는 로직
---
### 📖 참고 사항
리팩토링이 처음인 부분이기 때문에 먼저 일정 부분 작업을 진행한 후 나영님과 리뷰를 하고 추후 코드들을 어떻게 변경할 지 논의하려 합니다.
