### PR TITLE
조회수 중복 방지 기능 추가

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/FreeCommunityController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/FreeCommunityController.java
@@ -31,9 +31,10 @@ public class FreeCommunityController {
     @Operation(summary = "자유게시판 상세 조회(구현중)")
     @GetMapping()
     @PreAuthorize("isAuthenticated()")
-    public FreePostResponseDto getFreePost(@RequestParam("freeId") Long freeId) {
+    public FreePostResponseDto getFreePost(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                           @RequestParam("freeId") Long freeId) {
 
-        return freeCommunityService.getFreePost(freeId);
+        return freeCommunityService.getFreePost(userDetails.getUser(), freeId);
     }
 
     @Operation(summary = "자유게시판 글 작성(구현중)")

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/ShareController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/ShareController.java
@@ -39,9 +39,10 @@ public class ShareController {
 
     @Operation(summary = "마트/배달 게시글 상세 조회")
     @GetMapping(value = "")
-    @PreAuthorize("permitAll()")
-    public ResponseEntity<?> getMartByShareId(@RequestParam Long shareId) {
-        return ResponseEntity.ok().body(martService.getMartByShareId(shareId));
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getMartByShareId(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                              @RequestParam Long shareId) {
+        return ResponseEntity.ok().body(martService.getMartByShareId(userDetails.getUser(), shareId));
     }
 
     @Operation(summary = "마트/배달 게시글 작성")

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/HitTrack.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/HitTrack.java
@@ -1,0 +1,18 @@
+package dutchiepay.backend.domain.community.dto;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+
+@Builder
+@Getter
+@RedisHash(value = "hitTrack", timeToLive = 60 * 1)
+public class HitTrack {
+    @Id
+    private String id;
+
+    private Long userId;
+    private Long postId;
+    private String type;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/repository/HitTrackRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/repository/HitTrackRepository.java
@@ -1,0 +1,7 @@
+package dutchiepay.backend.domain.community.repository;
+
+import dutchiepay.backend.domain.community.dto.HitTrack;
+import org.springframework.data.repository.CrudRepository;
+
+public interface HitTrackRepository extends CrudRepository<HitTrack, String> {
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/FreeCommunityService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/FreeCommunityService.java
@@ -26,6 +26,7 @@ public class FreeCommunityService {
     private final FreeRepository freeRepository;
     private final CommentRepository commentRepository;
     private final UserUtilService userUtilService;
+    private final PostHitService postHitService;
 
 
     /**
@@ -44,11 +45,11 @@ public class FreeCommunityService {
      * @param freeId 조회할 게시글 Id
      * @return 게시글 상세 정보 dto
      */
-    public FreePostResponseDto getFreePost(Long freeId) {
-
+    public FreePostResponseDto getFreePost(User user, Long freeId) {
         Tuple freePost = qFreeRepository.getFreePost(freeId);
         Free free = freeRepository.findById(freeId)
                 .orElseThrow(() -> new CommunityException(CommunityErrorCode.CANNOT_FOUND_POST));
+        postHitService.increaseHitCount(user, "free", freeId);
         int count = commentRepository.countCommentByFree(free);
 
         return FreePostResponseDto.toDto(free.getUser(), free, count);

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class MartService {
+    private final PostHitService postHitService;
     private final ShareRepository shareRepository;
 
     @Transactional
@@ -33,7 +34,8 @@ public class MartService {
         shareRepository.softDelete(shareId);
     }
 
-    public GetMartResponseDto getMartByShareId(Long shareId) {
+    public GetMartResponseDto getMartByShareId(User user, Long shareId) {
+        postHitService.increaseHitCount(user, "share", shareId);
         validateShare(shareId);
         return shareRepository.getMartByShareId(shareId);
     }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/PostHitService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/PostHitService.java
@@ -1,0 +1,63 @@
+package dutchiepay.backend.domain.community.service;
+
+import dutchiepay.backend.domain.commerce.repository.FreeRepository;
+import dutchiepay.backend.domain.community.dto.HitTrack;
+import dutchiepay.backend.domain.community.repository.HitTrackRepository;
+import dutchiepay.backend.domain.community.repository.ShareRepository;
+import dutchiepay.backend.entity.Free;
+import dutchiepay.backend.entity.Share;
+import dutchiepay.backend.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostHitService {
+    private final FreeRepository freeRepository;
+    private final ShareRepository shareRepository;
+    private final HitTrackRepository hitTrackRepository;
+
+    @Transactional
+    public void increaseHitCount(User user, String type, Long postId) {
+        Object post = findPostType(type, postId);
+        if (post == null) {
+            return;
+        }
+
+        String hitTrackKey = user.getUserId() + "_" + postId + "_" + type;
+
+        if (!hitTrackRepository.existsById(hitTrackKey)) {
+            incrementHitCount(post, type);
+
+            HitTrack hitTrack = HitTrack.builder()
+                    .id(hitTrackKey)
+                    .userId(user.getUserId())
+                    .postId(postId)
+                    .type(type)
+                    .build();
+
+            hitTrackRepository.save(hitTrack);
+        }
+    }
+
+    private Object findPostType(String type, Long postId) {
+        if (type.equals("free")) {
+            return freeRepository.findById(postId)
+                    .orElseThrow(() -> new IllegalArgumentException("Invalid post type"));
+        } else if (type.equals("share")) {
+            return shareRepository.findById(postId)
+                    .orElseThrow(() -> new IllegalArgumentException("Invalid post type"));
+        } else {
+            return null;
+        }
+    }
+
+    private void incrementHitCount(Object post, String type) {
+        if (type.equals("free") && post instanceof Free freePost) {
+            freePost.increaseHitCount();
+        } else if (type.equals("share") && post instanceof Share sharePost) {
+            sharePost.increaseHitCount();
+        }
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Free.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Free.java
@@ -46,4 +46,7 @@ public class Free extends Auditing {
         this.postImg = dto.getThumbnail();
     }
 
+    public void increaseHitCount() {
+        this.hits++;
+    }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Share.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Share.java
@@ -85,4 +85,8 @@ public class Share extends Auditing {
     public void changeStatus(String status) {
         this.state = status;
     }
+
+    public void increaseHitCount() {
+        this.hits++;
+    }
 }


### PR DESCRIPTION
### ⚡이슈 번호
resolve #

---
### ✅ PR 종류
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 조회수 중복 방지를 위한 HitTrack DTO, HitTrackRepository, PostHitService 클래스 추가
- ttl의 경우 90분으로 설정(60 * 90)
- 유저id_postId_type 형태의 고유 키 생성으로 각 게시글별로 중복되지 않도록 설정
- 기존 마트/배달 게시글 상세 조회 및 자유게시글 상세 조회 로직에 조회수 증가 로직 별도로 추가
---
### 📖 참고 사항
