### PR TITLE
마트/배달 일부 오류 해결 / 최근 거래 완료글 조회 기능 추가

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/CommunityController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/CommunityController.java
@@ -1,20 +1,26 @@
 package dutchiepay.backend.domain.community.controller;
 
 import dutchiepay.backend.domain.community.dto.ChangeStatusRequestDto;
+import dutchiepay.backend.domain.community.service.CommunityService;
 import dutchiepay.backend.domain.community.service.MartService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/community")
 public class CommunityController {
+    private final CommunityService communityService;
     private final MartService martService;
+
+    @GetMapping("/recent-posts")
+    @PreAuthorize("permitAll()")
+    public ResponseEntity<?> getUserCompleteRecentDeals(@RequestParam Long userId) {
+        return ResponseEntity.ok().body(communityService.getUserCompleteRecentDeals(userId));
+    }
+
 
     @PatchMapping("/status")
     @PreAuthorize("isAuthenticated()")
@@ -24,4 +30,5 @@ public class CommunityController {
         }
         return ResponseEntity.ok().build();
     }
+
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/CommunityController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/CommunityController.java
@@ -16,7 +16,7 @@ public class CommunityController {
     private final MartService martService;
 
     @GetMapping("/recent-posts")
-    @PreAuthorize("permitAll()")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getUserCompleteRecentDeals(@RequestParam Long userId) {
         return ResponseEntity.ok().body(communityService.getUserCompleteRecentDeals(userId));
     }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/GetUserCompleteRecentDealsDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/GetUserCompleteRecentDealsDto.java
@@ -1,0 +1,16 @@
+package dutchiepay.backend.domain.community.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetUserCompleteRecentDealsDto {
+    private Long postId;
+    private String category;
+    private String title;
+    private LocalDateTime createdAt;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/repository/QShareRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/repository/QShareRepository.java
@@ -2,10 +2,15 @@ package dutchiepay.backend.domain.community.repository;
 
 import dutchiepay.backend.domain.community.dto.GetMartListResponseDto;
 import dutchiepay.backend.domain.community.dto.GetMartResponseDto;
+import dutchiepay.backend.domain.community.dto.GetUserCompleteRecentDealsDto;
 import dutchiepay.backend.entity.User;
+
+import java.util.List;
 
 public interface QShareRepository {
     GetMartListResponseDto getMartList(User user, String category, Long cursor, Integer limit);
 
     GetMartResponseDto getMartByShareId(Long shareId);
+
+    List<GetUserCompleteRecentDealsDto> getUserCompleteRecentDeals(Long userId);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/repository/QShareRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/repository/QShareRepositoryImpl.java
@@ -7,15 +7,13 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import dutchiepay.backend.domain.ChronoUtil;
 import dutchiepay.backend.domain.community.dto.GetMartListResponseDto;
 import dutchiepay.backend.domain.community.dto.GetMartResponseDto;
+import dutchiepay.backend.domain.community.dto.GetUserCompleteRecentDealsDto;
 import dutchiepay.backend.entity.QShare;
 import dutchiepay.backend.entity.QUser;
 import dutchiepay.backend.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -117,5 +115,22 @@ public class QShareRepositoryImpl implements QShareRepository{
                 .where(share.shareId.eq(shareId))
                 .where(share.deletedAt.isNull())
                 .fetchOne();
+    }
+
+    @Override
+    public List<GetUserCompleteRecentDealsDto> getUserCompleteRecentDeals(Long userId) {
+        return jpaQueryFactory
+                .select(Projections.constructor(GetUserCompleteRecentDealsDto.class,
+                        share.shareId.as("postId"),
+                        share.category,
+                        share.title,
+                        share.createdAt))
+                .from(share)
+                .where(share.user.userId.eq(userId))
+                .where(share.state.eq("모집완료"))
+                .where(share.deletedAt.isNull())
+                .orderBy(share.createdAt.desc())
+                .limit(5)
+                .fetch();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/CommunityService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/CommunityService.java
@@ -1,4 +1,17 @@
 package dutchiepay.backend.domain.community.service;
 
+import dutchiepay.backend.domain.community.dto.GetUserCompleteRecentDealsDto;
+import dutchiepay.backend.domain.community.repository.ShareRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class CommunityService {
+    private final ShareRepository shareRepository;
+    public List<GetUserCompleteRecentDealsDto> getUserCompleteRecentDeals(Long userId) {
+        return shareRepository.getUserCompleteRecentDeals(userId);
+    }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
@@ -20,7 +20,7 @@ public class MartService {
     public CreateShareResponseDto createMart(User user, CreateMartRequestDto req) {
         validateTitle(req.getTitle());
         validateCategory(req.getCategory());
-        return CreateShareResponseDto.from(createShareEntity(req, user.getLocation()));
+        return CreateShareResponseDto.from(createShareEntity(req, user));
     }
 
     @Transactional
@@ -59,13 +59,14 @@ public class MartService {
         }
     }
 
-    private Share createShareEntity(CreateMartRequestDto req, String location) {
+    private Share createShareEntity(CreateMartRequestDto req, User user) {
         Share newShare = Share.builder()
+                .user(user)
                 .title(req.getTitle())
                 .date(req.getDate())
                 .maximum(req.getMaximum())
                 .meetingPlace(req.getMeetingPlace())
-                .location(location)
+                .location(user.getLocation())
                 .state("모집중")
                 .latitude(req.getLatitude())
                 .longitude(req.getLongitude())

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
@@ -101,8 +101,4 @@ public class MartService {
 
         share.changeStatus(req.getStatus());
     }
-
-    public Object getUserDoneDeals(Long userId) {
-        return null;
-    }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
@@ -19,6 +19,7 @@ public class MartService {
     @Transactional
     public CreateShareResponseDto createMart(User user, CreateMartRequestDto req) {
         validateTitle(req.getTitle());
+        validateCategory(req.getCategory());
         return CreateShareResponseDto.from(createShareEntity(req, user.getLocation()));
     }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
@@ -101,4 +101,8 @@ public class MartService {
 
         share.changeStatus(req.getStatus());
     }
+
+    public Object getUserDoneDeals(Long userId) {
+        return null;
+    }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
@@ -275,10 +275,10 @@ public class QProfileRepositoryImpl implements QProfileRepository {
                 "'마트/배달' as category, " +
                 "NULL as commentCount, " +
                 "share.thumbnail, " +
-                "user.nickname as writerNickname, " +
-                "user.profile_img as writerProfileImage " +
+                "users.nickname as writerNickname, " +
+                "users.profile_img as writerProfileImage " +
                 "FROM share " +
-                "LEFT JOIN user ON share.user_id = user.user_id " +
+                "LEFT JOIN users ON share.user_id = users.user_id " +
                 "WHERE share.user_id = :userId AND share.deleted_at IS NULL " +
                 "UNION ALL " +
                 "SELECT " +
@@ -289,10 +289,10 @@ public class QProfileRepositoryImpl implements QProfileRepository {
                 "'자유' as category, " +
                 "(SELECT COUNT(*) FROM comment WHERE free_id = free.free_id AND deleted_at IS NULL) as commentCount, " +
                 "NULL as thumbnail, " +
-                "user.nickname as writerNickname, " +
-                "user.profile_img as writerProfileImage " +
+                "users.nickname as writerNickname, " +
+                "users.profile_img as writerProfileImage " +
                 "FROM free " +
-                "LEFT JOIN user ON free.user_id = user.user_id " +
+                "LEFT JOIN users ON free.user_id = users.user_id " +
                 "WHERE free.user_id = :userId AND free.deleted_at IS NULL " +
                 "ORDER BY writeTime DESC " +
                 "LIMIT :limit OFFSET :offset";


### PR DESCRIPTION
### ⚡이슈 번호
resolve #168 

---
### ✅ PR 종류
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 마트/배달 게시글 작성 시 카테고리가 mart/delivery 가 아닐 경우 에러를 반환하도록 하였습니다
- 마트/배달 게시글 작성 시 user가 매핑되지 않아 정상적으로 데이터가 들어가지 않아 조회 시 writer 데이터가 반환되지 않는 문제를 해결했습니다
- 내가 쓴 게시글/댓글 조회 시 쿼리의 테이블명이 user로 잘못 작성되어 있어 users로 변경하였습니다
- 특정 유저의 최근 거래 완료글 조회 기능을 추가하였습니다.
---
### 📖 참고 사항
