### PR TITLE
마트/배달 상세조회(수정용) 기능 추가, 내가 쓴 게시글/댓글 totalPost 오류 해결

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/ShareController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/ShareController.java
@@ -38,12 +38,20 @@ public class ShareController {
     }
 
     @Operation(summary = "마트/배달 게시글 상세 조회")
-    @GetMapping(value = "")
+    @GetMapping("")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getMartByShareId(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                               @RequestParam Long shareId) {
         return ResponseEntity.ok().body(martService.getMartByShareId(userDetails.getUser(), shareId));
     }
+
+    @Operation(summary = "마트/배달 게시글 상세 조회(수정용)")
+    @GetMapping("/{shareId}")
+    @PreAuthorize("isAuthenticated() && @shareAuthorManager.isShareAuthor(#shareId, authentication.getPrincipal())")
+    public ResponseEntity<?> getMArtByShareIdForUpdate(@PathVariable Long shareId) {
+        return ResponseEntity.ok().body(martService.getMartByShareIdForUpdate(shareId));
+    }
+
 
     @Operation(summary = "마트/배달 게시글 작성")
     @PostMapping("")

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/GetMartUpdateResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/GetMartUpdateResponseDto.java
@@ -1,0 +1,20 @@
+package dutchiepay.backend.domain.community.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetMartUpdateResponseDto {
+    private String title;
+    private String category;
+    private String content;
+    private String meetingPlace;
+    private String longitude;
+    private String latitude;
+    private String date;
+    private Integer maximum;
+    private String thumbnail;
+    private String[] images;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/repository/QShareRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/repository/QShareRepository.java
@@ -2,6 +2,7 @@ package dutchiepay.backend.domain.community.repository;
 
 import dutchiepay.backend.domain.community.dto.GetMartListResponseDto;
 import dutchiepay.backend.domain.community.dto.GetMartResponseDto;
+import dutchiepay.backend.domain.community.dto.GetMartUpdateResponseDto;
 import dutchiepay.backend.domain.community.dto.GetUserCompleteRecentDealsDto;
 import dutchiepay.backend.entity.User;
 
@@ -13,4 +14,6 @@ public interface QShareRepository {
     GetMartResponseDto getMartByShareId(Long shareId);
 
     List<GetUserCompleteRecentDealsDto> getUserCompleteRecentDeals(Long userId);
+
+    GetMartUpdateResponseDto getMartByShareIdForUpdate(Long shareId);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/repository/QShareRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/repository/QShareRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import dutchiepay.backend.domain.ChronoUtil;
 import dutchiepay.backend.domain.community.dto.GetMartListResponseDto;
 import dutchiepay.backend.domain.community.dto.GetMartResponseDto;
+import dutchiepay.backend.domain.community.dto.GetMartUpdateResponseDto;
 import dutchiepay.backend.domain.community.dto.GetUserCompleteRecentDealsDto;
 import dutchiepay.backend.entity.QShare;
 import dutchiepay.backend.entity.QUser;
@@ -132,5 +133,39 @@ public class QShareRepositoryImpl implements QShareRepository{
                 .orderBy(share.createdAt.desc())
                 .limit(5)
                 .fetch();
+    }
+
+    @Override
+    public GetMartUpdateResponseDto getMartByShareIdForUpdate(Long shareId) {
+        Tuple result = jpaQueryFactory
+                .select(share.title,
+                        share.category,
+                        share.contents,
+                        share.meetingPlace,
+                        share.longitude,
+                        share.latitude,
+                        share.date,
+                        share.maximum,
+                        share.thumbnail,
+                        share.images)
+                .from(share)
+                .where(share.shareId.eq(shareId))
+                .where(share.deletedAt.isNull())
+                .fetchOne();
+
+        String[] images = result.get(share.images) == null ? new String[0] : result.get(share.images).split(",");
+
+        return GetMartUpdateResponseDto.builder()
+                .title(result.get(share.title))
+                .category(result.get(share.category))
+                .content(result.get(share.contents))
+                .meetingPlace(result.get(share.meetingPlace))
+                .longitude(result.get(share.longitude))
+                .latitude(result.get(share.latitude))
+                .date(result.get(share.date))
+                .maximum(result.get(share.maximum))
+                .thumbnail(result.get(share.thumbnail))
+                .images(images)
+                .build();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
@@ -41,6 +41,11 @@ public class MartService {
         return shareRepository.getMartByShareId(shareId);
     }
 
+    public GetMartUpdateResponseDto getMartByShareIdForUpdate(Long shareId) {
+        validateShare(shareId);
+        return shareRepository.getMartByShareIdForUpdate(shareId);
+    }
+
     public GetMartListResponseDto getMartList(User user, String category, Long cursor, Integer limit) {
         validateCategory(category);
         return shareRepository.getMartList(user, category, cursor, limit);


### PR DESCRIPTION
### ⚡이슈 번호
resolve #173 

---
### ✅ PR 종류
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 마트/배달 상세조회(수정용) 기능을 추가하였습니다.
- 토큰과 작성자가 다를 경우 401 에러가 아닌 403 Forbidden을 반환하게 됩니다.
- 내가 작성한 게시글/댓글의 경우 db상의 전체 데이터가 아닌, 반환되는 데이터 개수만 주어지게 되어, 이를 별도의 count쿼리를 통해 해결하였습니다.
---
### 📖 참고 사항
