### PR TITLE
마트/배달 오류 수정

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/CommunityController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/CommunityController.java
@@ -3,6 +3,7 @@ package dutchiepay.backend.domain.community.controller;
 import dutchiepay.backend.domain.community.dto.ChangeStatusRequestDto;
 import dutchiepay.backend.domain.community.service.CommunityService;
 import dutchiepay.backend.domain.community.service.MartService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -15,7 +16,8 @@ public class CommunityController {
     private final CommunityService communityService;
     private final MartService martService;
 
-    @GetMapping("/recent-posts")
+    @Operation(summary = "최근 거래 완료글 조회")
+    @GetMapping("/recent-post")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> getUserCompleteRecentDeals(@RequestParam Long userId) {
         return ResponseEntity.ok().body(communityService.getUserCompleteRecentDeals(userId));

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/ShareController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/ShareController.java
@@ -24,7 +24,7 @@ public class ShareController {
     @Operation(summary = "마트/배달 리스트 조회")
     @GetMapping(value = "/list")
     @PreAuthorize("permitAll()")
-    public ResponseEntity<?> getMartList(@RequestParam String category,
+    public ResponseEntity<?> getMartList(@RequestParam(required = false) String category,
                                          @RequestParam(required = false) Long cursor,
                                          @RequestParam Integer limit) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/CreateMartRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/CreateMartRequestDto.java
@@ -19,5 +19,6 @@ public class CreateMartRequestDto {
     private String longitude;
     private String content;
     private String thumbnail;
+    private String[] images;
     private String category;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/UpdateMartRequestDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/UpdateMartRequestDto.java
@@ -1,6 +1,5 @@
 package dutchiepay.backend.domain.community.dto;
 
-import jakarta.validation.constraints.Max;
 import lombok.*;
 
 @Getter
@@ -11,12 +10,11 @@ public class UpdateMartRequestDto {
     private Long shareId;
     private String title;
     private String date;
-    @Max(value = 10, message = "최대 인원은 10명을 넘을 수 없습니다.")
-    private Integer maximum;
     private String meetingPlace;
     private String latitude;
     private String longitude;
     private String content;
     private String thumbnail;
     private String category;
+    private String[] images;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
@@ -78,6 +78,7 @@ public class MartService {
                 .contents(req.getContent())
                 .thumbnail(req.getThumbnail())
                 .category(req.getCategory())
+                .images(String.join(",", req.getImages()))
                 .now(1)
                 .hits(0)
                 .build();

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
@@ -88,7 +88,7 @@ public class MartService {
     }
 
     private void validateCategory(String category) {
-        if (!category.equals("mart") && !category.equals("delivery")) {
+        if (category != null && !category.equals("mart") && !category.equals("delivery")) {
             throw new CommunityException(CommunityErrorCode.INVALID_CATEGORY);
         }
     }

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Share.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Share.java
@@ -76,13 +76,14 @@ public class Share extends Auditing {
 
     public void update(UpdateMartRequestDto req) {
         this.title = req.getTitle();
-        this.maximum = req.getMaximum();
+        this.date = req.getDate();
         this.meetingPlace = req.getMeetingPlace();
         this.latitude = req.getLatitude();
         this.longitude = req.getLongitude();
         this.contents = req.getContent();
         this.thumbnail = req.getThumbnail();
         this.category = req.getCategory();
+        this.images = String.join(",", req.getImages());
     }
 
     public void changeStatus(String status) {


### PR DESCRIPTION
### ⚡이슈 번호
resolve #175 

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 마트/배달 게시글 리스트 조회 시 category가 파라미터로 들어오지 않는 경우 모든 데이터 return 할 수 있도록 변경
- 최근 거래 완료 게시글 url api명세서에 맞게 변경(recent-posts -> recent-post)
- 마트/배달 게시글 작성 시 images 배열 받도록 변경(배열로 받아서 "," delim으로 설정하여 1개의 String으로 변경)
- 마트/배달 게시글 수정 시 maximum제거 및 images 배열 받도록 변경
---
### 📖 참고 사항
