### PR TITLE
169/feat search

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/dto/AddEntityDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/dto/AddEntityDto.java
@@ -22,4 +22,5 @@ public class AddEntityDto {
     private String contactNumber;
     private String representative;
     private String storeAddress;
+    private String tag;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
@@ -447,4 +447,12 @@ public class QBuyRepositoryImpl implements QBuyRepository{
         }
         return photo == 1 ? review.reviewImg.isNotNull() : null;
     }
+
+    public List<String> findAllTags() {
+        return jpaQueryFactory
+                .select(buy.tags)
+                .from(buy)
+                .where(buy.tags.isNotNull())
+                .fetch();
+    }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/service/CommerceService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/service/CommerceService.java
@@ -129,6 +129,7 @@ public class CommerceService {
                 .deadline(addEntityDto.getDeadline())
                 .skeleton(addEntityDto.getSkeleton())
                 .nowCount(0)
+                .tags(addEntityDto.getTag())
                 .build());
 
         for (String c : addEntityDto.getCategory()) {

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/CommentResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/CommentResponseDto.java
@@ -1,9 +1,9 @@
 package dutchiepay.backend.domain.community.dto;
+import com.querydsl.core.Tuple;
 import dutchiepay.backend.entity.Comment;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -14,27 +14,21 @@ public class CommentResponseDto {
     private Long cursor;
 
     @Getter
-    @Builder
+    @NoArgsConstructor
     public static class CommentDetail {
         private Long commentId;
         private String nickname;
         private String profileImg;
-        private String content;
+        private String contents;
         private LocalDateTime createdAt;
         private Boolean isModified;
         private String userState;
+        private Boolean hasMore;
 
-        public static CommentDetail toDto(Comment comment) {
-            return CommentDetail.builder()
-                    .commentId(comment.getCommentId())
-                    .nickname(comment.getUser().getNickname())
-                    .profileImg(comment.getUser().getProfileImg())
-                    .content(comment.getContents())
-                    .createdAt(comment.getCreatedAt())
-                    .isModified(comment.getUpdatedAt() == null)
-                    .userState(comment.getUser().getState() == 0? "회원" : "탈퇴")
-                    .build();
+        public void setHasMore(boolean hasMore) {
+            this.hasMore = hasMore;
         }
+
     }
     public static CommentResponseDto toDto(List<CommentDetail> comments, Long cursor) {
         return CommentResponseDto.builder().comments(comments).cursor(cursor).build();

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/search/controller/SearchController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/search/controller/SearchController.java
@@ -1,4 +1,39 @@
 package dutchiepay.backend.domain.search.controller;
 
+import dutchiepay.backend.domain.search.dto.CommerceSearchResponseDto;
+import dutchiepay.backend.domain.search.dto.DictionaryResponseDto;
+import dutchiepay.backend.domain.search.service.SearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/search")
+@RequiredArgsConstructor
 public class SearchController {
+
+    private final SearchService searchService;
+
+    @Operation(summary = "검색 사전")
+    @GetMapping
+    public ResponseEntity<DictionaryResponseDto> getSearchDictionary() {
+        return ResponseEntity.ok(searchService.getSearchDictionary());
+    }
+
+    @Operation(summary = "공동구매 검색")
+    @GetMapping("/commerce")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<CommerceSearchResponseDto> commerceSearch(@RequestParam("keyword") String keyword,
+                                                                    @RequestParam("filter") String filter,
+                                                                    @RequestParam("end") int end,
+                                                                    @RequestParam(value="cursor", required = false) Long cursor,
+                                                                    @RequestParam("limit") int limit) {
+        return ResponseEntity.ok(searchService.commerceSearch(keyword, filter, end, cursor, limit));
+    }
+
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/search/controller/SearchController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/search/controller/SearchController.java
@@ -1,12 +1,15 @@
 package dutchiepay.backend.domain.search.controller;
 
+import dutchiepay.backend.domain.commerce.dto.GetBuyListResponseDto;
 import dutchiepay.backend.domain.search.dto.CommerceSearchResponseDto;
 import dutchiepay.backend.domain.search.dto.DictionaryResponseDto;
 import dutchiepay.backend.domain.search.service.SearchService;
+import dutchiepay.backend.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -21,19 +24,22 @@ public class SearchController {
 
     @Operation(summary = "검색 사전")
     @GetMapping
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<DictionaryResponseDto> getSearchDictionary() {
         return ResponseEntity.ok(searchService.getSearchDictionary());
     }
 
     @Operation(summary = "공동구매 검색")
     @GetMapping("/commerce")
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<CommerceSearchResponseDto> commerceSearch(@RequestParam("keyword") String keyword,
-                                                                    @RequestParam("filter") String filter,
-                                                                    @RequestParam("end") int end,
-                                                                    @RequestParam(value="cursor", required = false) Long cursor,
-                                                                    @RequestParam("limit") int limit) {
-        return ResponseEntity.ok(searchService.commerceSearch(keyword, filter, end, cursor, limit));
+    @PreAuthorize("permitAll()")
+    public ResponseEntity<GetBuyListResponseDto> commerceSearch(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                @RequestParam("keyword") String keyword,
+                                                                @RequestParam("filter") String filter,
+                                                                @RequestParam("end") int end,
+                                                                @RequestParam(value="cursor", required = false) Long cursor,
+                                                                @RequestParam("limit") int limit) {
+        return ResponseEntity.ok(searchService.commerceSearch(userDetails == null? null: userDetails.getUser(),
+                                                                keyword, filter, end, cursor, limit));
     }
 
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/search/dto/CommerceSearchResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/search/dto/CommerceSearchResponseDto.java
@@ -1,0 +1,10 @@
+package dutchiepay.backend.domain.search.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CommerceSearchResponseDto {
+    String[] tags;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/search/dto/DictionaryResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/search/dto/DictionaryResponseDto.java
@@ -1,0 +1,12 @@
+package dutchiepay.backend.domain.search.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Set;
+
+@Getter
+@Builder
+public class DictionaryResponseDto {
+    private Set<String> tags;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/search/dto/SearchDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/search/dto/SearchDto.java
@@ -1,4 +1,0 @@
-package dutchiepay.backend.domain.search.dto;
-
-public class SearchDto {
-}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/search/repository/QSearchRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/search/repository/QSearchRepository.java
@@ -1,0 +1,9 @@
+package dutchiepay.backend.domain.search.repository;
+
+import dutchiepay.backend.domain.commerce.dto.GetBuyListResponseDto;
+import dutchiepay.backend.entity.User;
+
+public interface QSearchRepository {
+
+    GetBuyListResponseDto searchCommerce(User user, String filter, String keyword, int end, Long cursor, int limit);
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/search/repository/QSearchRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/search/repository/QSearchRepositoryImpl.java
@@ -1,0 +1,268 @@
+package dutchiepay.backend.domain.search.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dutchiepay.backend.domain.commerce.dto.GetBuyListResponseDto;
+import dutchiepay.backend.domain.commerce.exception.CommerceErrorCode;
+import dutchiepay.backend.domain.commerce.exception.CommerceException;
+import dutchiepay.backend.entity.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+
+@Repository
+@RequiredArgsConstructor
+public class QSearchRepositoryImpl implements QSearchRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    QBuy buy = QBuy.buy;
+    QProduct product = QProduct.product;
+    QReview review = QReview.review;
+    QLike like = QLike.like;
+    QScore score = QScore.score;
+    QBuyCategory buyCategory = QBuyCategory.buyCategory;
+    QCategory category = QCategory.category;
+
+    @Override
+    public GetBuyListResponseDto searchCommerce(User user, String filter, String keyword, int end, Long cursor, int limit) {
+        if (cursor == null) {
+            cursor = Long.MAX_VALUE;
+        }
+
+        BooleanExpression conditions = null;
+
+        if (end == 0) {
+            BooleanExpression dateCondition = buy.deadline.after(LocalDate.now().minusDays(1));
+            conditions = conditions == null ? dateCondition : conditions.and(dateCondition);
+        }
+
+        OrderSpecifier[] orderBy;
+        BooleanExpression cursorCondition = null;
+        switch (filter) {
+            case "like":
+                orderBy = new OrderSpecifier[]{like.count().desc(), buy.buyId.desc()};
+                if (cursor < Long.MAX_VALUE) {
+                    Long cursorLike = jpaQueryFactory
+                            .select(like.count())
+                            .from(like)
+                            .join(like.buy, buy)
+                            .where(buy.buyId.eq(cursor))
+                            .fetchOne();
+
+                    if (cursorLike != null) {
+                        cursorCondition = like.count().lt(cursorLike)
+                                .or(like.count().eq(cursorLike))
+                                .and(buy.buyId.loe(cursor));
+                    }
+                }
+                break;
+            case "endDate":
+                if (cursor < Long.MAX_VALUE) {
+                    Tuple cursorInfo = jpaQueryFactory
+                            .select(buy.deadline,
+                                    Expressions.cases()
+                                            .when(buy.deadline.goe(LocalDate.now()))
+                                            .then(0)
+                                            .otherwise(1))
+                            .from(buy)
+                            .where(buy.buyId.eq(cursor))
+                            .fetchOne();
+
+                    if (cursorInfo != null) {
+                        LocalDate cursorEndDate = cursorInfo.get(0, LocalDate.class);
+                        Integer cursorGroup = cursorInfo.get(1, Integer.class);
+
+                        BooleanExpression sameGroupCondition = Expressions.cases()
+                                .when(buy.deadline.goe(LocalDate.now()))
+                                .then(0)
+                                .otherwise(1)
+                                .eq(cursorGroup)
+                                .and(buy.deadline.gt(cursorEndDate)
+                                        .or(buy.deadline.eq(cursorEndDate)
+                                                .and(buy.buyId.loe(cursor))));
+
+                        BooleanExpression nextGroupCondition = Expressions.cases()
+                                .when(buy.deadline.goe(LocalDate.now()))
+                                .then(0)
+                                .otherwise(1)
+                                .gt(cursorGroup);
+
+                        cursorCondition = sameGroupCondition.or(nextGroupCondition);
+                    }
+                }
+
+                orderBy = new OrderSpecifier[]{
+                        Expressions.cases()
+                                .when(buy.deadline.goe(LocalDate.now()))
+                                .then(0)
+                                .otherwise(1)
+                                .asc(),
+                        buy.deadline.asc(),
+                        buy.buyId.desc()
+                };
+                break;
+            case "discount":
+                if (cursor < Long.MAX_VALUE) {
+                    Integer cursorDiscount = jpaQueryFactory
+                            .select(product.discountPercent)
+                            .from(buy)
+                            .join(buy.product, product)
+                            .where(buy.buyId.eq(cursor))
+                            .fetchOne();
+
+                    if (cursorDiscount != null) {
+                        cursorCondition = product.discountPercent.lt(cursorDiscount)
+                                .or(product.discountPercent.eq(cursorDiscount));
+                    }
+                }
+                orderBy = new OrderSpecifier[]{product.discountPercent.desc(), buy.buyId.desc()};
+                break;
+            case "newest":
+                orderBy = new OrderSpecifier[]{buy.buyId.desc()};
+                conditions = conditions != null ? conditions.and(buy.buyId.loe(cursor)) : buy.buyId.loe(cursor);
+                break;
+            default:
+                throw new CommerceException(CommerceErrorCode.INVALID_FILTER);
+        }
+
+        JPAQuery<Tuple> query = jpaQueryFactory
+                .select(buy.buyId,
+                        product.productName,
+                        product.productImg,
+                        product.originalPrice,
+                        product.salePrice,
+                        product.discountPercent,
+                        buy.skeleton,
+                        buy.nowCount,
+                        buy.deadline,
+                        user != null ? JPAExpressions
+                                .selectOne()
+                                .from(like)
+                                .where(like.buy.eq(buy)
+                                        .and(like.user.eq(user)))
+                                .exists()
+                                : Expressions.constant(false),
+                        JPAExpressions
+                                .select(review.count())
+                                .from(review)
+                                .where(review.order.buy.eq(buy))
+                                .where(review.deletedAt.isNull()))
+                .from(buy)
+                .join(buy.product, product)
+                .leftJoin(buyCategory).on(buyCategory.buy.eq(buy))
+                .leftJoin(category).on(buyCategory.category.eq(category))
+                .leftJoin(review).on(review.order.buy.eq(buy))
+                .leftJoin(like).on(like.buy.eq(buy));
+
+        query.where(conditions, buy.tags.contains(keyword).or(buy.title.contains(keyword)))
+                .groupBy(buy.buyId, product.productName, product.productImg, product.originalPrice,
+                        product.salePrice, product.discountPercent, buy.skeleton, buy.nowCount, buy.deadline)
+                .limit(limit + 1);
+
+        if (filter.equals("like")) {
+            query.having(cursorCondition);
+            query.orderBy(orderBy);
+        } else {
+            query.where(cursorCondition);
+            query.orderBy(orderBy);
+        }
+
+        List<Tuple> results = query.fetch();
+
+        List<Long> buyIds = results.stream()
+                .map(result -> result.get(0, Long.class))
+                .toList();
+
+        List<Tuple> ratingCountsList = jpaQueryFactory
+                .select(
+                        score.buy.buyId,
+                        score.one,
+                        score.two,
+                        score.three,
+                        score.four,
+                        score.five,
+                        score.count
+                )
+                .from(score)
+                .where(score.buy.buyId.in(buyIds))
+                .groupBy(score.buy.buyId)
+                .fetch();
+
+        Map<Long, Tuple> ratingMap = new HashMap<>();
+        for (Tuple tuple : ratingCountsList) {
+            Long buyId = tuple.get(score.buy.buyId);
+            ratingMap.put(buyId, tuple);
+        }
+
+        List<GetBuyListResponseDto.ProductDto> products = new ArrayList<>();
+        int count = 0;
+        for (Tuple result : results) {
+            if (count >= limit) {
+                break;
+            }
+
+            Long buyId = result.get(0, Long.class);
+            Tuple ratingCounts = ratingMap.getOrDefault(buyId, null);
+
+            double average = 0.0;
+
+            if (ratingCounts != null) {
+                Integer one = Optional.ofNullable(ratingCounts.get(1, Integer.class)).orElse(0);
+                Integer two = Optional.ofNullable(ratingCounts.get(2, Integer.class)).orElse(0);
+                Integer three = Optional.ofNullable(ratingCounts.get(3, Integer.class)).orElse(0);
+                Integer four = Optional.ofNullable(ratingCounts.get(4, Integer.class)).orElse(0);
+                Integer five = Optional.ofNullable(ratingCounts.get(5, Integer.class)).orElse(0);
+                Integer total = Optional.ofNullable(ratingCounts.get(6, Integer.class)).orElse(0);
+
+                if (total != 0) {
+                    average = (one + two * 2 + three * 3 + four * 4 + five * 5) / (double) total;
+                }
+            }
+
+            GetBuyListResponseDto.ProductDto.ProductDtoBuilder dtoBuilder = GetBuyListResponseDto.ProductDto.builder()
+                    .buyId(buyId)
+                    .productName(result.get(1, String.class))
+                    .productImg(result.get(2, String.class))
+                    .productPrice(result.get(3, Integer.class))
+                    .discountPrice(result.get(4, Integer.class))
+                    .discountPercent(result.get(5, Integer.class))
+                    .skeleton(result.get(6, Integer.class))
+                    .nowCount(result.get(7, Integer.class))
+                    .expireDate(calculateExpireDate(result.get(8, LocalDate.class)))
+                    .isLiked(result.get(9, Boolean.class))
+                    .rating(average)
+                    .reviewCount(result.get(10, Long.class));
+
+            products.add(dtoBuilder.build());
+            count++;
+        }
+
+        Long nextCursor = results.size() > limit ? results.get(limit).get(buy.buyId) : null;
+
+        return GetBuyListResponseDto.builder()
+                .products(products)
+                .cursor(nextCursor)
+                .build();
+    }
+
+    private int calculateExpireDate(LocalDate deadline) {
+        if (deadline.isBefore(LocalDate.now())) {
+            return -1;
+        } else if (deadline.isEqual(LocalDate.now())) {
+            return 0;
+        } else {
+            return (int) ChronoUnit.DAYS.between(LocalDate.now(), deadline);
+        }
+    }
+
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/search/repository/SearchRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/search/repository/SearchRepository.java
@@ -1,4 +1,0 @@
-package dutchiepay.backend.domain.search.repository;
-
-public interface SearchRepository {
-}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/search/service/SearchService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/search/service/SearchService.java
@@ -1,4 +1,37 @@
 package dutchiepay.backend.domain.search.service;
 
+import dutchiepay.backend.domain.commerce.repository.BuyRepository;
+import dutchiepay.backend.domain.commerce.repository.QBuyRepository;
+import dutchiepay.backend.domain.commerce.repository.QBuyRepositoryImpl;
+import dutchiepay.backend.domain.search.dto.CommerceSearchResponseDto;
+import dutchiepay.backend.domain.search.dto.DictionaryResponseDto;
+import dutchiepay.backend.domain.search.repository.QSearchRepository;
+import dutchiepay.backend.entity.Buy;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
 public class SearchService {
+
+    private final QSearchRepository qSearchRepository;
+    private final QBuyRepositoryImpl qBuyRepository;
+
+    public DictionaryResponseDto getSearchDictionary() {
+        Set<String> tags = qBuyRepository.findAllTags().stream()
+                .flatMap(s -> Arrays.stream(s.split(", ")))
+                .collect(Collectors.toSet());
+        return DictionaryResponseDto.builder().tags(tags).build();
+    }
+
+    public CommerceSearchResponseDto commerceSearch(String keyword, String filter, int end, Long cursor, int limit) {
+
+        return null;
+    }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/search/service/SearchService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/search/service/SearchService.java
@@ -1,5 +1,6 @@
 package dutchiepay.backend.domain.search.service;
 
+import dutchiepay.backend.domain.commerce.dto.GetBuyListResponseDto;
 import dutchiepay.backend.domain.commerce.repository.BuyRepository;
 import dutchiepay.backend.domain.commerce.repository.QBuyRepository;
 import dutchiepay.backend.domain.commerce.repository.QBuyRepositoryImpl;
@@ -7,6 +8,7 @@ import dutchiepay.backend.domain.search.dto.CommerceSearchResponseDto;
 import dutchiepay.backend.domain.search.dto.DictionaryResponseDto;
 import dutchiepay.backend.domain.search.repository.QSearchRepository;
 import dutchiepay.backend.entity.Buy;
+import dutchiepay.backend.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -30,8 +32,8 @@ public class SearchService {
         return DictionaryResponseDto.builder().tags(tags).build();
     }
 
-    public CommerceSearchResponseDto commerceSearch(String keyword, String filter, int end, Long cursor, int limit) {
+    public GetBuyListResponseDto commerceSearch(User user, String keyword, String filter, int end, Long cursor, int limit) {
 
-        return null;
+        return qSearchRepository.searchCommerce(user, filter, keyword, end, cursor, limit);
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Buy.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Buy.java
@@ -38,6 +38,9 @@ public class Buy extends Auditing {
     @Column(nullable = false)
     private int nowCount;
 
+    @Column
+    private String tags;
+
     public void upCount(int count) {
         this.nowCount += count;
     }


### PR DESCRIPTION
### ⚡이슈 번호
resolve #169

---
### ✅ PR 종류
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 검색어 사전 (tags에 있는 모든 words 반환) 구현
- 공동구매 검색 구현... 이지만 성민님 구현해주신 getBuyList랑 거의 차이가 없어서... duplicate warning이 뜰 정도로 거의 겹칩니다...^_ㅠ 
![image](https://github.com/user-attachments/assets/10deb936-e356-4048-8cb4-3c95b8ac88ef)
![image](https://github.com/user-attachments/assets/1a5e29ac-802e-4f2b-9339-5b0a6e900c7e)
이 부분 말고는 전부 동일한데(심지어 Dto도 GetBuyListResponseDto를 씁니다) 기존 코드를 어떻게 사용할 수가 없어서.. 일단 냅다 갖다 썼습니다 ㅠ 뭔가..좋은 아이디어가 있으면 말씀주세요....
- 프론트 측에서 답글 조회 할 때 원댓에 달려있는 답글이 6개 이상인지 확인하는 hasMore 필드를 추가해 달라고 요청받아 해당사항 구현하였습니다

---
### 📖 참고 사항
