### PR TITLE
fix | 삭제된 댓글과 탈퇴한 회원의 댓글 response 수정

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/CommentResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/CommentResponseDto.java
@@ -30,23 +30,16 @@ public class CommentResponseDto {
         private Boolean hasMore;
 
         public static CommentDetail toDto(Tuple tuple, boolean hasMore) {
-            CommentDetailBuilder builder = CommentDetail.builder();
             boolean leaved = tuple.get(comment.user.state) != 0;
             boolean deleted = tuple.get(comment.deletedAt) != null;
-            if (deleted || leaved) {
-                builder.nickname(null)
-                        .profileImg(null)
-                        .isModified(null);
-            } else {
-                builder.nickname(tuple.get(comment.user.nickname))
-                        .profileImg(tuple.get(comment.user.profileImg))
-                        .createdAt(tuple.get(comment.createdAt))
-                        .isModified(tuple.get(comment.updatedAt).isAfter(tuple.get(comment.createdAt)));
-            }
-            if (deleted) builder.contents("삭제된 댓글입니다.");
-            else builder.contents(tuple.get(comment.contents));
 
-            return builder.commentId(tuple.get(comment.commentId)).userState(leaved ? "탈퇴" : "회원")
+            return CommentDetail.builder().commentId(tuple.get(comment.commentId))
+                    .nickname(deleted || leaved ? null : tuple.get(comment.user.nickname))
+                    .profileImg(deleted || leaved ? null : tuple.get(comment.user.profileImg))
+                    .contents(deleted ? "삭제된 댓글입니다." : tuple.get(comment.contents))
+                    .createdAt(tuple.get(comment.createdAt))
+                    .isModified(deleted || leaved ? null : tuple.get(comment.updatedAt).isAfter(tuple.get(comment.createdAt)))
+                    .userState(leaved ? "탈퇴" : "회원")
                     .hasMore(hasMore).build();
         }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/ReCommentResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/ReCommentResponseDto.java
@@ -28,26 +28,17 @@ public class ReCommentResponseDto {
     public static ReCommentResponseDto toDto(Tuple tuple, Tuple mentionedUser) {
         boolean originUserLeaved = tuple.get(comment.user.state) != 0;
         boolean mentionedUserLeaved = mentionedUser.get(comment.user.state) != 0;
-        ReCommentResponseDtoBuilder builder = ReCommentResponseDto.builder();
-        if (originUserLeaved) {
-            builder.nickname(null)
-                    .profileImg(null)
-                    .isModified(null)
-                    .userState("탈퇴");
-        } else {
-            builder.nickname(tuple.get(comment.user.nickname))
-                    .profileImg(tuple.get(comment.user.profileImg))
-                    .isModified(tuple.get(comment.updatedAt).isAfter(tuple.get(comment.createdAt)))
-                    .userState("회원");
-        }
-        if (mentionedUserLeaved) {
-            builder.mentionedNickname(null).mentionedUserState("탈퇴");
-        } else {
-            builder.mentionedNickname(mentionedUser.get(comment.user.nickname)).mentionedUserState("회원");
-        }
 
-        return builder.commentId(tuple.get(comment.commentId))
+        return ReCommentResponseDto.builder()
+                .commentId(tuple.get(comment.commentId))
+                .mentionedNickname(mentionedUserLeaved ? null : tuple.get(comment.user.nickname))
+                .nickname(originUserLeaved ? null : tuple.get(comment.user.nickname))
+                .profileImg(originUserLeaved ? null : tuple.get(comment.user.profileImg))
                 .contents(tuple.get(comment.contents))
-                .createdAt(tuple.get(comment.createdAt)).build();
+                .createdAt(tuple.get(comment.createdAt))
+                .isModified(originUserLeaved ? null : tuple.get(comment.updatedAt).isAfter(tuple.get(comment.createdAt)))
+                .userState(originUserLeaved ? "탈퇴" : "회원")
+                .mentionedUserState(mentionedUserLeaved ? "탈퇴" : "회원")
+                .build();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/ReCommentResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/ReCommentResponseDto.java
@@ -1,11 +1,15 @@
 package dutchiepay.backend.domain.community.dto;
 
+import com.querydsl.core.Tuple;
 import dutchiepay.backend.entity.Comment;
+import dutchiepay.backend.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static dutchiepay.backend.entity.QComment.comment;
 
 @Getter
 @Builder
@@ -15,23 +19,35 @@ public class ReCommentResponseDto {
     private String mentionedNickname;
     private String nickname;
     private String profileImg;
-    private String content;
+    private String contents;
     private LocalDateTime createdAt;
     private Boolean isModified;
     private String userState;
     private String mentionedUserState;
 
-    public static ReCommentResponseDto toDto(Comment comment, Comment mentionedComment) {
-        return ReCommentResponseDto.builder()
-                .commentId(comment.getCommentId())
-                .mentionedNickname(mentionedComment.getUser().getNickname())
-                .nickname(comment.getUser().getNickname())
-                .profileImg(comment.getUser().getProfileImg())
-                .content(comment.getContents())
-                .createdAt(comment.getCreatedAt())
-                .isModified(comment.getUpdatedAt().isAfter(comment.getCreatedAt()))
-                .userState(comment.getUser().getState() == 0 ? "회원" : "탈퇴")
-                .mentionedUserState(mentionedComment.getUser().getState() == 0 ? "회원" : "탈퇴")
-                .build();
+    public static ReCommentResponseDto toDto(Tuple tuple, Tuple mentionedUser) {
+        boolean originUserLeaved = tuple.get(comment.user.state) != 0;
+        boolean mentionedUserLeaved = mentionedUser.get(comment.user.state) != 0;
+        ReCommentResponseDtoBuilder builder = ReCommentResponseDto.builder();
+        if (originUserLeaved) {
+            builder.nickname(null)
+                    .profileImg(null)
+                    .isModified(null)
+                    .userState("탈퇴");
+        } else {
+            builder.nickname(tuple.get(comment.user.nickname))
+                    .profileImg(tuple.get(comment.user.profileImg))
+                    .isModified(tuple.get(comment.updatedAt).isAfter(tuple.get(comment.createdAt)))
+                    .userState("회원");
+        }
+        if (mentionedUserLeaved) {
+            builder.mentionedNickname(null).mentionedUserState("탈퇴");
+        } else {
+            builder.mentionedNickname(mentionedUser.get(comment.user.nickname)).mentionedUserState("회원");
+        }
+
+        return builder.commentId(tuple.get(comment.commentId))
+                .contents(tuple.get(comment.contents))
+                .createdAt(tuple.get(comment.createdAt)).build();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/repository/QFreeRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/repository/QFreeRepositoryImpl.java
@@ -194,7 +194,7 @@ public class QFreeRepositoryImpl implements QFreeRepository {
                 .fetch();
 
         Long nextCursor = comments.size() > limit ? comments.get(limit).get(comment.commentId) : null;
-        return CommentResponseDto.toDto(comments.stream()
+        return CommentResponseDto.toDto(comments.stream().limit(limit)
                 .map(c -> CommentResponseDto.CommentDetail.toDto(c,
                         countRecomments(c.get(comment.commentId)) > 5)).toList(), nextCursor);
     }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/config/RedisConfig.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/config/RedisConfig.java
@@ -21,15 +21,15 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private String port;
 
-    @Value("${REDIS_PASSWORD}")
-    private String password;
+    /*@Value("${REDIS_PASSWORD}")
+    private String password;*/
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
         redisStandaloneConfiguration.setHostName(host);
         redisStandaloneConfiguration.setPort(Integer.parseInt(port));
-        redisStandaloneConfiguration.setPassword(password);
+        //redisStandaloneConfiguration.setPassword(password);
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/config/RedisConfig.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/config/RedisConfig.java
@@ -21,15 +21,15 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private String port;
 
-    /*@Value("${REDIS_PASSWORD}")
-    private String password;*/
+    @Value("${REDIS_PASSWORD}")
+    private String password;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
         redisStandaloneConfiguration.setHostName(host);
         redisStandaloneConfiguration.setPort(Integer.parseInt(port));
-        //redisStandaloneConfiguration.setPassword(password);
+        redisStandaloneConfiguration.setPassword(password);
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 


### PR DESCRIPTION
### ⚡이슈 번호
resolve #183 

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 삭제된 댓글 -> 닉네임 등 null, "삭제된 게시글입니다" 반환 수정
- 탈퇴한 회원 댓글 -> 프로필이미지 등 null 반환 수정
- 언급한 댓글도 확인하는 로직 추가
---
### 📖 참고 사항
