### PR TITLE
알림목록 조회 응답 변경 / 공동구매 성공 및 실패 시 알림 기능 추가

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/repository/QBuyRepositoryImpl.java
@@ -3,9 +3,7 @@ package dutchiepay.backend.domain.commerce.repository;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -24,7 +22,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/dto/GetNoticeListResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/dto/GetNoticeListResponseDto.java
@@ -14,6 +14,6 @@ public class GetNoticeListResponseDto {
     private String content;
     private String relativeTime;
     private Long pageId;
-    private Integer commentId;
+    private Long commentId;
     private Boolean hasMore;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/dto/GetNoticeListResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/dto/GetNoticeListResponseDto.java
@@ -8,9 +8,12 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GetNoticeListResponseDto {
+    private Long noticeId;
     private String type;
     private String origin;
+    private String content;
     private String relativeTime;
-    private Long id;
-    private Integer count;
+    private Long pageId;
+    private Integer commentId;
+    private Boolean hasMore;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/repository/NoticeRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/repository/NoticeRepository.java
@@ -8,11 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public interface NoticeRepository extends JpaRepository<Notice, Long> {
+public interface NoticeRepository extends JpaRepository<Notice, Long>, QNoticeRepository {
     List<Notice> findByUserAndIsReadFalseAndCreatedAtAfter(User user, LocalDateTime minus);
-
-    @Query("SELECT n FROM Notice n WHERE n.user = :user AND n.createdAt >= :time AND n.deletedAt IS NULL ORDER BY n.createdAt DESC")
-    List<Notice> findRecentNotices(User user, LocalDateTime time);
 
     @Query("SELECT CASE WHEN COUNT(n) > 0 THEN true ELSE false END FROM Notice n WHERE n.user = :user AND n.isRead = false AND n.createdAt >= :time AND n.deletedAt IS NULL")
     boolean existUnreadNotification(User user, LocalDateTime time);

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/repository/QNoticeRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/repository/QNoticeRepository.java
@@ -1,0 +1,10 @@
+package dutchiepay.backend.domain.notice.repository;
+
+import dutchiepay.backend.domain.notice.dto.GetNoticeListResponseDto;
+import dutchiepay.backend.entity.User;
+
+import java.util.List;
+
+public interface QNoticeRepository {
+    List<GetNoticeListResponseDto> findRecentNotices(User user);
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/repository/QNoticeRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/repository/QNoticeRepositoryImpl.java
@@ -1,0 +1,103 @@
+package dutchiepay.backend.domain.notice.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dutchiepay.backend.domain.ChronoUtil;
+import dutchiepay.backend.domain.notice.dto.GetNoticeListResponseDto;
+import dutchiepay.backend.entity.Notice;
+import dutchiepay.backend.entity.QNotice;
+import dutchiepay.backend.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class QNoticeRepositoryImpl implements QNoticeRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    QNotice notice = QNotice.notice;
+
+    @Override
+    public List<GetNoticeListResponseDto> findRecentNotices(User user) {
+        QNotice subNotice = new QNotice("subNotice");
+
+        List<Tuple> notices = jpaQueryFactory
+                .select(
+                        notice,
+                        JPAExpressions
+                                .select(notice.count())
+                                .from(notice)
+                                .where(
+                                        baseNoticeCondition(user),
+                                        noticeTypeCondition()
+                                )
+                )
+                .from(notice)
+                .where(
+                        baseNoticeCondition(user),
+                        noticeTypeCondition()
+                )
+                .groupBy(notice.origin, notice.type)
+                .having(
+                        notice.noticeId.eq(
+                                JPAExpressions
+                                        .select(subNotice.noticeId)
+                                        .from(subNotice)
+                                        .where(
+                                                subNotice.user.eq(user),
+                                                subNotice.origin.eq(notice.origin),
+                                                subNotice.type.eq(notice.type)
+                                        )
+                                        .orderBy(subNotice.createdAt.desc())
+                                        .limit(1)
+                        )
+                )
+                .orderBy(notice.createdAt.desc())
+                .fetch();
+
+        List<GetNoticeListResponseDto> result = new ArrayList<>();
+
+        for (Tuple t : notices) {
+            Notice n = t.get(0, Notice.class);
+            Long originNoticeCount = t.get(1, Long.class);
+
+            GetNoticeListResponseDto dto = GetNoticeListResponseDto.builder()
+                    .noticeId(n.getNoticeId())
+                    .type(n.getType())
+                    .origin(n.getOrigin())
+                    .content(n.getContent())
+                    .relativeTime(ChronoUtil.formatDateTime(n.getCreatedAt()))
+                    .pageId(n.getOriginId())
+                    .commentId(n.getCommentId())
+                    .hasMore(originNoticeCount > 1)
+                    .build();
+
+            result.add(dto);
+        }
+
+        return result;
+    }
+
+    private BooleanExpression noticeTypeCondition() {
+        return notice.type.eq("commerce").and(notice.originId.isNull())
+                .or(
+                        notice.type.in("comment", "reply", "chat")
+                                .and(notice.origin.isNotNull())
+                );
+    }
+
+    private BooleanExpression baseNoticeCondition(User user) {
+        return notice.user.eq(user)
+                .and(notice.createdAt.goe(LocalDateTime.now().minusDays(7)))
+                .and(notice.deletedAt.isNull());
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/service/NoticeService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/service/NoticeService.java
@@ -77,28 +77,4 @@ public class NoticeService {
             }
         }
     }
-
-
-
-//    private List<GetNoticeListResponseDto> makeNoticeListResponse(Map<String, List<Notice>> originNoticeMap) {
-//        List<GetNoticeListResponseDto> response = new ArrayList<>();
-//
-//        for (List<Notice> l : originNoticeMap.values()) {
-//            if (!l.isEmpty()) {
-//                Notice latestNotice = l.get(0);
-//
-//                GetNoticeListResponseDto dto = GetNoticeListResponseDto.builder()
-//                        .type(latestNotice.getType())
-//                        .origin(latestNotice.getOrigin())
-//                        .relativeTime(ChronoUtil.timesAgo(latestNotice.getCreatedAt()))
-//                        .id(latestNotice.getOriginId())
-//                        .count(l.size())
-//                        .build();
-//
-//                response.add(dto);
-//            }
-//        }
-//
-//        return response;
-//    }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/service/NoticeService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/service/NoticeService.java
@@ -1,6 +1,5 @@
 package dutchiepay.backend.domain.notice.service;
 
-import dutchiepay.backend.domain.ChronoUtil;
 import dutchiepay.backend.domain.notice.dto.UnreadStatus;
 import dutchiepay.backend.domain.notice.dto.GetNoticeListResponseDto;
 import dutchiepay.backend.domain.notice.dto.NoticeDto;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/service/NoticeService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/service/NoticeService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -25,11 +24,9 @@ public class NoticeService {
     private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
 
     public List<GetNoticeListResponseDto> getNotices(User user) {
-        List<Notice> notices = noticeUtilService.findRecentNotices(user, LocalDateTime.now().minusDays(7));
+        return noticeUtilService.findRecentNotices(user);
 
-        Map<String, List<Notice>> originNoticeMap = noticeUtilService.makeNoticeMapByOrigin(notices);
 
-        return makeNoticeListResponse(originNoticeMap);
     }
 
     public SseEmitter subscribe(User user) {
@@ -84,25 +81,25 @@ public class NoticeService {
 
 
 
-    private List<GetNoticeListResponseDto> makeNoticeListResponse(Map<String, List<Notice>> originNoticeMap) {
-        List<GetNoticeListResponseDto> response = new ArrayList<>();
-
-        for (List<Notice> l : originNoticeMap.values()) {
-            if (!l.isEmpty()) {
-                Notice latestNotice = l.get(0);
-
-                GetNoticeListResponseDto dto = GetNoticeListResponseDto.builder()
-                        .type(latestNotice.getType())
-                        .origin(latestNotice.getOrigin())
-                        .relativeTime(ChronoUtil.timesAgo(latestNotice.getCreatedAt()))
-                        .id(latestNotice.getOriginId())
-                        .count(l.size())
-                        .build();
-
-                response.add(dto);
-            }
-        }
-
-        return response;
-    }
+//    private List<GetNoticeListResponseDto> makeNoticeListResponse(Map<String, List<Notice>> originNoticeMap) {
+//        List<GetNoticeListResponseDto> response = new ArrayList<>();
+//
+//        for (List<Notice> l : originNoticeMap.values()) {
+//            if (!l.isEmpty()) {
+//                Notice latestNotice = l.get(0);
+//
+//                GetNoticeListResponseDto dto = GetNoticeListResponseDto.builder()
+//                        .type(latestNotice.getType())
+//                        .origin(latestNotice.getOrigin())
+//                        .relativeTime(ChronoUtil.timesAgo(latestNotice.getCreatedAt()))
+//                        .id(latestNotice.getOriginId())
+//                        .count(l.size())
+//                        .build();
+//
+//                response.add(dto);
+//            }
+//        }
+//
+//        return response;
+//    }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/service/NoticeUtilService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/service/NoticeUtilService.java
@@ -1,6 +1,7 @@
 package dutchiepay.backend.domain.notice.service;
 
 import dutchiepay.backend.domain.community.service.CommunityUtilService;
+import dutchiepay.backend.domain.notice.dto.GetNoticeListResponseDto;
 import dutchiepay.backend.domain.notice.repository.NoticeRepository;
 import dutchiepay.backend.entity.Comment;
 import dutchiepay.backend.entity.Notice;
@@ -20,8 +21,8 @@ public class NoticeUtilService {
     private final NoticeRepository noticeRepository;
     private final CommunityUtilService communityUtilService;
 
-    public List<Notice> findRecentNotices(User user, LocalDateTime time) {
-        return noticeRepository.findRecentNotices(user, time);
+    public List<GetNoticeListResponseDto> findRecentNotices(User user) {
+        return noticeRepository.findRecentNotices(user);
     }
 
     public List<Notice> findByUserAndIsReadFalseAndCreatedAtAfter(User user, LocalDateTime minus) {

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/service/NoticeUtilService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/service/NoticeUtilService.java
@@ -25,34 +25,12 @@ public class NoticeUtilService {
         return noticeRepository.findRecentNotices(user);
     }
 
-    public List<Notice> findByUserAndIsReadFalseAndCreatedAtAfter(User user, LocalDateTime minus) {
-        return noticeRepository.findByUserAndIsReadFalseAndCreatedAtAfter(user, minus);
-    }
-
-    public Map<String, List<Notice>> makeNoticeMapByOrigin(List<Notice> notices) {
-        Map<String, List<Notice>> noticeMap = new HashMap<>();
-
-        for (Notice n : notices) {
-            if (!noticeMap.containsKey(n.getOrigin())) {
-                noticeMap.put(n.getOrigin(), new ArrayList<>());
-            }
-
-            noticeMap.get(n.getOrigin()).add(n);
-        }
-
-        return noticeMap;
-    }
-
     public Notice createCommentNotice(String writer, Comment comment) {
         if (comment.getParentId() == null) {
-            if (validatePostAuthor(writer, comment)) {
-                return null;
-            }
+            if (validatePostAuthor(writer, comment)) return null;
             return createPostCommentNotice(writer, comment);
         } else {
-            if (validateCommentAuthor(writer, comment)) {
-                return null;
-            }
+            if (validateCommentAuthor(writer, comment)) return null;
             return createReplyCommentNotice(writer, comment);
         }
     }
@@ -70,7 +48,9 @@ public class NoticeUtilService {
                 .user(comment.getFree().getUser())
                 .type("comment")
                 .origin(comment.getFree().getTitle())
+                .content(comment.getContents())
                 .originId(comment.getFree().getFreeId())
+                .commentId(comment.getCommentId())
                 .writer(writer)
                 .isRead(false)
                 .build());
@@ -82,7 +62,9 @@ public class NoticeUtilService {
                 .user(c.getUser())
                 .type("reply")
                 .origin(c.getContents())
+                .content(comment.getContents())
                 .originId(c.getCommentId())
+                .commentId(comment.getParentId())
                 .writer(writer)
                 .isRead(false)
                 .build());

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/service/NoticeUtilService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/service/NoticeUtilService.java
@@ -5,9 +5,11 @@ import dutchiepay.backend.domain.notice.dto.GetNoticeListResponseDto;
 import dutchiepay.backend.domain.notice.repository.NoticeRepository;
 import dutchiepay.backend.entity.Comment;
 import dutchiepay.backend.entity.Notice;
+import dutchiepay.backend.entity.Order;
 import dutchiepay.backend.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -72,5 +74,31 @@ public class NoticeUtilService {
 
     public boolean existUnreadNotification(User user, LocalDateTime time) {
         return noticeRepository.existUnreadNotification(user, time);
+    }
+
+    public Notice createCommerceNotice(Order order, String status) {
+        String type = null;
+
+        if (status.equals("배송준비중")) {
+            type = "commerce_success";
+        } else if (status.equals("공구실패")) {
+            type = "commerce_fail";
+        }
+
+        return noticeRepository.save(Notice.builder()
+                .user(order.getUser())
+                .type(type)
+                .origin(order.getProduct().getProductName())
+                .content(null)
+                .originId(order.getBuy().getBuyId())
+                .commentId(null)
+                .writer(null)
+                .isRead(false)
+                .build());
+    }
+
+    @Transactional
+    public void readNotice(Notice notice) {
+        notice.read();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Notice.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Notice.java
@@ -32,4 +32,8 @@ public class Notice extends Auditing {
     private String writer;
 
     private Boolean isRead;
+
+    public void read() {
+        this.isRead = true;
+    }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Notice.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Notice.java
@@ -23,7 +23,11 @@ public class Notice extends Auditing {
 
     private String origin;
 
+    private String content;
+
     private Long originId;
+
+    private Long commentId;
 
     private String writer;
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/scheduler/OrderStatusUpdateSchedule.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/scheduler/OrderStatusUpdateSchedule.java
@@ -1,5 +1,6 @@
 package dutchiepay.backend.global.scheduler;
 
+import dutchiepay.backend.domain.notice.service.NoticeService;
 import dutchiepay.backend.domain.order.repository.OrderRepository;
 import dutchiepay.backend.domain.order.service.OrderService;
 import dutchiepay.backend.entity.Buy;
@@ -21,6 +22,7 @@ import java.util.List;
 public class OrderStatusUpdateSchedule {
     private final OrderService orderService;
     private final OrderRepository orderRepository;
+    private final NoticeService noticeService;
 
     private static final String IN_PROGRESS = "공구진행중";
     private static final String PREPARING_SHIPMENT = "배송준비중";
@@ -30,7 +32,7 @@ public class OrderStatusUpdateSchedule {
     private static final String FAILED = "공구실패";
     private static final String EXCHANGE_REQUESTED = "교환요청";
 
-    @Scheduled(cron = "0 5 0 * * ?")
+    @Scheduled(cron = "0 * * * * ?")
     @Transactional
     public void orderStatusUpdate() {
         log.info("주문 상태 업데이트 스케쥴링 시작");
@@ -54,10 +56,12 @@ public class OrderStatusUpdateSchedule {
                 if (buy.getNowCount() >= buy.getSkeleton()) {
                     order.changeStatus(PREPARING_SHIPMENT);
                     updateList.add(order);
+                    noticeService.createAndSendCommerceNotice(order, PREPARING_SHIPMENT);
                 } else {
                     order.changeStatus(FAILED);
                     orderService.autoCancelPurchase(order.getOrderId());
                     updateList.add(order);
+                    noticeService.createAndSendCommerceNotice(order, FAILED);
                 }
             }
         }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/scheduler/OrderStatusUpdateSchedule.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/scheduler/OrderStatusUpdateSchedule.java
@@ -32,7 +32,7 @@ public class OrderStatusUpdateSchedule {
     private static final String FAILED = "공구실패";
     private static final String EXCHANGE_REQUESTED = "교환요청";
 
-    @Scheduled(cron = "0 * * * * ?")
+    @Scheduled(cron = "0 5 0 * * ?")
     @Transactional
     public void orderStatusUpdate() {
         log.info("주문 상태 업데이트 스케쥴링 시작");


### PR DESCRIPTION
### ⚡이슈 번호
resolve #179 

---
### ✅ PR 종류
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 알림 목록 조회 api의 응답 구조가 변경됨에 따라 관련 dto 및 쿼리를 변경하였습니다.
- 최초 sse 연결 시 읽지 않은 알림이 존재하는지 여부를 반환합니다.
- 공동구매 성공/실패 시 알림을 보내도록 설정하였습니다.
---
### 📖 참고 사항
