### PR TITLE
feat | dto 변수명 변경, 검색어 빈 문자열일 때 에러 반환

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/exception/CommunityErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/exception/CommunityErrorCode.java
@@ -20,6 +20,7 @@ public enum CommunityErrorCode implements StatusCode {
     ILLEGAL_FILTER(HttpStatus.BAD_REQUEST, "필터 값이 유효하지 않습니다."),
     OVER_CONTENT_LENGTH(HttpStatus.BAD_REQUEST, "제한된 길이를 초과하였습니다."),
     ILLEGAL_TYPE(HttpStatus.BAD_REQUEST, "타입 값이 유효하지 않습니다."),
+    BLANK_WORD(HttpStatus.BAD_REQUEST, "검색어가 입력되지 않았습니다."),
     /**
      * 404 Not Found
      */

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/GetMyLikesResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/dto/GetMyLikesResponseDto.java
@@ -10,8 +10,8 @@ public class GetMyLikesResponseDto {
     private Long buyId;
     private String[] category;
     private String productName;
-    private Integer originalPrice;
-    private Integer salePrice;
+    private Integer productPrice;
+    private Integer discountPrice;
     private Integer discountPercent;
     private String productImg;
     private Double rating;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/search/service/SearchService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/search/service/SearchService.java
@@ -2,10 +2,13 @@ package dutchiepay.backend.domain.search.service;
 
 import dutchiepay.backend.domain.commerce.dto.GetBuyListResponseDto;
 import dutchiepay.backend.domain.commerce.repository.QBuyRepositoryImpl;
+import dutchiepay.backend.domain.community.exception.CommunityErrorCode;
+import dutchiepay.backend.domain.community.exception.CommunityException;
 import dutchiepay.backend.domain.search.dto.DictionaryResponseDto;
 import dutchiepay.backend.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -41,6 +44,7 @@ public class SearchService {
      */
     public GetBuyListResponseDto commerceSearch(User user, String filter, String keyword, int end, Long cursor, int limit) {
 
+        if (!StringUtils.hasText(keyword)) throw new CommunityException(CommunityErrorCode.BLANK_WORD);
         return qBuyRepository.getBuyList(user, filter, null, keyword, end, cursor, limit);
     }
 }


### PR DESCRIPTION
### ⚡이슈 번호
resolve #194 

---
### ✅ PR 종류
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 공동구매 검색 결과 반환 시 공동구매 리스트 dto를 사용했는데, api 명세서와 변수명이 달라서 프론트측에서 수정 요청이 있었습니다. 프론트 측에서는 좋아요한 상품 목록과 컴포넌트를 같이 써서 둘 중 하나로 변수명을 맞춰야 한다고 해서 공동구매 리스트에 변수명을 맞췄습니다.
- 공동구매 검색어로 빈 문자열이 들어왔을 때 전체 공동구매 리스트가 반환되어서, exception 발생하도록 추가했습니다.
---
### 📖 참고 사항
