### PR TITLE
fix | 인기/추천 게시글 프로필이미지, 닉네임 null 반환 오류 수정

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/CommunityController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/CommunityController.java
@@ -1,8 +1,11 @@
 package dutchiepay.backend.domain.community.controller;
 
 import dutchiepay.backend.domain.community.dto.ChangeStatusRequestDto;
+import dutchiepay.backend.domain.community.exception.CommunityErrorCode;
+import dutchiepay.backend.domain.community.exception.CommunityException;
 import dutchiepay.backend.domain.community.service.CommunityService;
 import dutchiepay.backend.domain.community.service.MartService;
+import dutchiepay.backend.domain.community.service.PurchaseService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class CommunityController {
     private final CommunityService communityService;
     private final MartService martService;
+    private final PurchaseService purchaseService;
 
     @Operation(summary = "최근 거래 완료글 조회")
     @GetMapping("/recent-post")
@@ -29,8 +33,12 @@ public class CommunityController {
     public ResponseEntity<?> changeStatus(@RequestBody ChangeStatusRequestDto req) {
         if (req.getCategory().equals("마트/배달")) {
             martService.changeStatus(req);
+            return ResponseEntity.ok().build();
+        } else if (req.getCategory().equals("나눔/거래")) {
+            purchaseService.changeStatus(req);
+            return ResponseEntity.ok().build();
         }
-        return ResponseEntity.ok().build();
+        throw new CommunityException(CommunityErrorCode.INVALID_CATEGORY);
     }
 
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/HotAndRecommendsResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/HotAndRecommendsResponseDto.java
@@ -29,8 +29,8 @@ public class HotAndRecommendsResponseDto {
         public static Posts toDto(Tuple result, Long count) {
             return Posts.builder()
                     .freeId(result.get(free.freeId))
-                    .writerProfileImg(result.get(user.profileImg))
-                    .writer(result.get(user.nickname))
+                    .writerProfileImg(result.get(free.user.profileImg))
+                    .writer(result.get(free.user.nickname))
                     .title(result.get(free.title))
                     .commentCount(count)
                     .build();

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/PurchaseResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/PurchaseResponseDto.java
@@ -13,7 +13,7 @@ public class PurchaseResponseDto {
     private String writerProfileImage;
     private String title;
     private String category;
-    private String contents;
+    private String content;
     private String goods;
     private Integer price;
     private String meetingPlace;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/repository/QFreeRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/repository/QFreeRepositoryImpl.java
@@ -135,8 +135,8 @@ public class QFreeRepositoryImpl implements QFreeRepository {
 
         return jpaQueryFactory
                 .select(free.freeId,
-                        free.user.profileImg.as("writerProfileImg"),
-                        free.user.nickname.as("writer"),
+                        free.user.profileImg,
+                        free.user.nickname,
                         free.title)
                 .from(free)
                 .leftJoin(free.user, user)
@@ -155,8 +155,8 @@ public class QFreeRepositoryImpl implements QFreeRepository {
 
         return jpaQueryFactory
                 .select(free.freeId,
-                        free.user.profileImg.as("writerProfileImg"),
-                        free.user.nickname.as("writer"),
+                        free.user.profileImg,
+                        free.user.nickname,
                         free.title)
                 .from(free)
                 .leftJoin(free.user, user)

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/repository/QPurchaseRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/repository/QPurchaseRepositoryImpl.java
@@ -76,7 +76,7 @@ public class QPurchaseRepositoryImpl {
                         user.profileImg.as("writerProfileImage"),
                         purchase.title,
                         purchase.category,
-                        purchase.contents,
+                        purchase.contents.as("content"),
                         purchase.goods,
                         purchase.price,
                         purchase.meetingPlace,

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/PurchaseService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/PurchaseService.java
@@ -68,7 +68,7 @@ public class PurchaseService {
                         .images(String.join(",", requestDto.getImages()))
                         .category(requestDto.getCategory())
                         .location(user.getLocation())
-                        .state("모집중").build()).getPurchaseId());
+                        .state(requestDto.getCategory().equals("share")? "나눔중" : "거래중").build()).getPurchaseId());
     }
 
     /**
@@ -115,5 +115,15 @@ public class PurchaseService {
         if (!user.getUserId().equals(purchase.getUser().getUserId()))
             throw new CommunityException(CommunityErrorCode.UNMATCHED_WRITER);
         return purchase;
+    }
+
+    /**
+     * 게시글 상태 변경
+     * @param req 게시글 Id와 변경할 상태가 담겨있는 dto
+     */
+    public void changeStatus(ChangeStatusRequestDto req) {
+        purchaseRepository.findById(req.getPostId())
+                .orElseThrow(() -> new CommunityException(CommunityErrorCode.CANNOT_FOUND_POST))
+                .changeState(req.getStatus());
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/config/RedisConfig.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/config/RedisConfig.java
@@ -21,15 +21,15 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private String port;
 
-    @Value("${REDIS_PASSWORD}")
-    private String password;
+    /*@Value("${REDIS_PASSWORD}")
+    private String password;*/
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
         redisStandaloneConfiguration.setHostName(host);
         redisStandaloneConfiguration.setPort(Integer.parseInt(port));
-        redisStandaloneConfiguration.setPassword(password);
+        //redisStandaloneConfiguration.setPassword(password);
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/config/RedisConfig.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/config/RedisConfig.java
@@ -21,15 +21,15 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private String port;
 
-    /*@Value("${REDIS_PASSWORD}")
-    private String password;*/
+    @Value("${REDIS_PASSWORD}")
+    private String password;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
         redisStandaloneConfiguration.setHostName(host);
         redisStandaloneConfiguration.setPort(Integer.parseInt(port));
-        //redisStandaloneConfiguration.setPassword(password);
+        redisStandaloneConfiguration.setPassword(password);
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 


### PR DESCRIPTION
### ⚡이슈 번호
resolve #211 

---
### ✅ PR 종류
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 인기/추천 게시글 프로필이미지, 닉네임이 null로 반환되던 오류 수정
- PurchaseResponseDto contents -> content 수정
- 나눔/거래 게시글 상태 변경 추가
    -  CommunityController에서 "마트/배달", "나눔/거래" category일때만 service로 넘어가고, 두 경우에 모두 해당하지 않으면 INVALID_CATEGORY Exception 발생하도록 변경했습니다.
---
### 📖 참고 사항
