### PR TITLE
알림 및 내가 작성한 글/댓글 이슈 문제 해결

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class MartService {
+    private final CommunityUtilService communityUtilService;
     private final PostHitService postHitService;
     private final ShareRepository shareRepository;
 
@@ -20,7 +21,8 @@ public class MartService {
     public CreateShareResponseDto createMart(User user, CreateMartRequestDto req) {
         validateTitle(req.getTitle());
         validateCategory(req.getCategory());
-        return CreateShareResponseDto.from(createShareEntity(req, user));
+        String description = communityUtilService.validatePostLength(req.getContent());
+        return CreateShareResponseDto.from(createShareEntity(req, user, description));
     }
 
     @Transactional
@@ -64,7 +66,7 @@ public class MartService {
         }
     }
 
-    private Share createShareEntity(CreateMartRequestDto req, User user) {
+    private Share createShareEntity(CreateMartRequestDto req, User user, String description) {
         Share newShare = Share.builder()
                 .user(user)
                 .title(req.getTitle())
@@ -76,6 +78,7 @@ public class MartService {
                 .latitude(req.getLatitude())
                 .longitude(req.getLongitude())
                 .contents(req.getContent())
+                .description(description)
                 .thumbnail(req.getThumbnail())
                 .category(req.getCategory())
                 .images(String.join(",", req.getImages()))

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/service/NoticeUtilService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/service/NoticeUtilService.java
@@ -68,7 +68,7 @@ public class NoticeUtilService {
                 .type("reply")
                 .origin(c.getContents())
                 .content(comment.getContents())
-                .originId(c.getCommentId())
+                .originId(c.getFree().getFreeId())
                 .commentId(comment.getParentId())
                 .writer(writer)
                 .isRead(false)

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
@@ -352,14 +352,17 @@ public class QProfileRepositoryImpl implements QProfileRepository {
                         free.createdAt,
                         free.description,
                         free.category,
+                        free.thumbnail,
+                        free.user.nickname,
+                        free.user.profileImg,
                         ExpressionUtils.as(
                                 JPAExpressions
                                         .select(comment.count())
                                         .from(comment)
                                         .where(comment.free.eq(free))
-                                        .where(comment.deletedAt.isNull()), "commentCount"),
-                        Expressions.nullExpression(String.class))
+                                        .where(comment.deletedAt.isNull()), "commentCount"))
                 .from(free)
+                .leftJoin(free.user)
                 .leftJoin(comment).on(comment.free.eq(free).and(comment.deletedAt.isNull()))
                 .where(comment.user.eq(user))
                 .groupBy(free.freeId)
@@ -377,6 +380,9 @@ public class QProfileRepositoryImpl implements QProfileRepository {
 
         List<MyPostsResponseDto.Post> result = new ArrayList<>();
         for (Tuple tuple : queryResult) {
+            System.out.println("===========================================");
+            System.out.println("tuple = " + tuple);
+            System.out.println("===========================================");
             LocalDateTime dbTime = tuple.get(free.createdAt);
 
             long daysBetween = ChronoUnit.DAYS.between(dbTime, LocalDateTime.now());
@@ -388,10 +394,10 @@ public class QProfileRepositoryImpl implements QProfileRepository {
                     .writeTime(writeTime)
                     .description(tuple.get(free.description))
                     .category(tuple.get(free.category))
-                    .commentCount(tuple.get(5, Long.class))
-                    .thumbnail(String.valueOf(free.thumbnail))
-                    .writerNickname(String.valueOf(free.user.nickname))
-                    .writerProfileImage(String.valueOf(free.user.profileImg))
+                    .commentCount(tuple.get(8, Long.class))
+                    .thumbnail(tuple.get(free.thumbnail))
+                    .writerNickname(tuple.get(free.user.nickname))
+                    .writerProfileImage(tuple.get(free.user.profileImg))
                     .build();
 
             result.add(data);

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
@@ -271,7 +271,7 @@ public class QProfileRepositoryImpl implements QProfileRepository {
                 "share.share_id as postId, " +
                 "share.title, " +
                 "share.created_at as writeTime, " +
-                "share.contents as content, " +
+                "share.description as content, " +
                 "'마트/배달' as category, " +
                 "NULL as commentCount, " +
                 "share.thumbnail, " +
@@ -350,7 +350,7 @@ public class QProfileRepositoryImpl implements QProfileRepository {
                         free.freeId,
                         free.title,
                         free.createdAt,
-                        free.contents,
+                        free.description,
                         free.category,
                         ExpressionUtils.as(
                                 JPAExpressions
@@ -386,12 +386,12 @@ public class QProfileRepositoryImpl implements QProfileRepository {
                     .postId(tuple.get(free.freeId))
                     .title(tuple.get(free.title))
                     .writeTime(writeTime)
-                    .description(tuple.get(free.contents))
+                    .description(tuple.get(free.description))
                     .category(tuple.get(free.category))
                     .commentCount(tuple.get(5, Long.class))
-                    .thumbnail(null)
-                    .writerNickname(null)
-                    .writerProfileImage(null)
+                    .thumbnail(String.valueOf(free.thumbnail))
+                    .writerNickname(String.valueOf(free.user.nickname))
+                    .writerProfileImage(String.valueOf(free.user.profileImg))
                     .build();
 
             result.add(data);
@@ -401,10 +401,6 @@ public class QProfileRepositoryImpl implements QProfileRepository {
                 .totalPost(totalPostCount.intValue())
                 .posts(result)
                 .build();
-    }
-
-    private BooleanExpression categoryEq(String categoryName) {
-        return category != null ? category.name.eq(categoryName) : null;
     }
 
     private String convertRelativeTime(LocalDateTime createdAt) {

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Share.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Share.java
@@ -28,6 +28,9 @@ public class Share extends Auditing {
     @Column(nullable = false, length = 1000)
     private String contents;
 
+    @Column(nullable = false)
+    private String description;
+
     // 카테고리
     @Column(nullable = false, length = 10)
     private String category;


### PR DESCRIPTION
### ⚡이슈 번호
resolve #213

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 마트/배달 게시글을 작성할 때 description 컬럼을 추가하고 별도로 저장하여 description 데이터를 클라이언트에 전달할 수 있도록 하였습니다.
- 내가 작성한 게시글 및 댓글 남긴 게시글에서 thumbnail, description, 게시글 작성자 정보를 전달하도록 쿼리를 변경하였습니다.
- 답글 알림 생성 시 originId가 원댓글의 id로 저장되지만 이를 게시글 id값으로 변경하였습니다.
---
### 📖 참고 사항
