### PR TITLE
215/fix purchase

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/CommunityController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/controller/CommunityController.java
@@ -38,7 +38,7 @@ public class CommunityController {
             purchaseService.changeStatus(req);
             return ResponseEntity.ok().build();
         }
-        throw new CommunityException(CommunityErrorCode.INVALID_CATEGORY);
+        throw new CommunityException(CommunityErrorCode.INVALID_POST_TYPE);
     }
 
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/PurchaseForUpdateDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/PurchaseForUpdateDto.java
@@ -1,7 +1,10 @@
 package dutchiepay.backend.domain.community.dto;
 
+import com.querydsl.core.Tuple;
 import lombok.Builder;
 import lombok.Getter;
+
+import static dutchiepay.backend.entity.QPurchase.purchase;
 
 @Getter
 @Builder
@@ -9,11 +12,29 @@ public class PurchaseForUpdateDto {
 
     private String title;
     private String category;
-    private String contents;
+    private String content;
     private String goods;
     private Integer price;
     private String meetingPlace;
     private String latitude;
     private String longitude;
+    private String thumbnail;
+    private String[] images;
+
+    public static PurchaseForUpdateDto toDto(Tuple tuple) {
+        String images = tuple.get(purchase.images);
+        return PurchaseForUpdateDto.builder()
+                .title(tuple.get(purchase.title))
+                .category(tuple.get(purchase.category))
+                .content(tuple.get(purchase.contents))
+                .goods(tuple.get(purchase.goods))
+                .price(tuple.get(purchase.price))
+                .meetingPlace(tuple.get(purchase.meetingPlace))
+                .latitude(tuple.get(purchase.latitude))
+                .longitude(tuple.get(purchase.longitude))
+                .thumbnail(tuple.get(purchase.thumbnail))
+                .images(images != null? images.split(", ") : null)
+                .build();
+    }
 
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/PurchaseListResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/dto/PurchaseListResponseDto.java
@@ -1,9 +1,13 @@
 package dutchiepay.backend.domain.community.dto;
 
+import com.querydsl.core.Tuple;
+import dutchiepay.backend.domain.ChronoUtil;
 import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static dutchiepay.backend.entity.QPurchase.purchase;
 
 @Getter
 @Builder
@@ -13,7 +17,7 @@ public class PurchaseListResponseDto {
     private Long cursor;
 
     @Getter
-    @AllArgsConstructor
+    @Builder
     public static class PurchaseDetail {
         private Long purchaseId;
         private String writer;
@@ -24,7 +28,24 @@ public class PurchaseListResponseDto {
         private String thumbnail;
         private String meetingPlace;
         private String state;
-        private LocalDateTime createdAt;
+        private String createdAt;
         private String category;
+        public static PurchaseDetail toDto(Tuple result) {
+            return PurchaseDetail.builder()
+                    .purchaseId(result.get(purchase.purchaseId))
+                    .writer(result.get(purchase.user.nickname))
+                    .writerProfileImg(result.get(purchase.user.profileImg))
+                    .title(result.get(purchase.title))
+                    .goods(result.get(purchase.goods))
+                    .price(result.get(purchase.price))
+                    .thumbnail(result.get(purchase.thumbnail))
+                    .meetingPlace(result.get(purchase.meetingPlace))
+                    .state(result.get(purchase.state))
+                    .createdAt(ChronoUtil.timesAgo(result.get(purchase.createdAt)))
+                    .category(result.get(purchase.category))
+                    .build();
+        }
     }
+
+
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/exception/CommunityErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/exception/CommunityErrorCode.java
@@ -27,7 +27,7 @@ public enum CommunityErrorCode implements StatusCode {
     /**
      * 404 Not Found
      */
-    CANNOT_FOUND_POST(HttpStatus.NOT_FOUND, "자유 게시글을 찾을 수 없습니다."),
+    CANNOT_FOUND_POST(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
     CANNOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, "원 댓글을 찾을 수 없습니다.");
 
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/exception/CommunityErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/exception/CommunityErrorCode.java
@@ -23,6 +23,7 @@ public enum CommunityErrorCode implements StatusCode {
     BLANK_WORD(HttpStatus.BAD_REQUEST, "검색어가 입력되지 않았습니다."),
     ILLEGAL_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 요청입니다"),
     INVALID_POST_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 게시글 타입입니다."),
+    ALREADY_DONE(HttpStatus.BAD_REQUEST, "이미 완료된 게시글입니다."),
     /**
      * 404 Not Found
      */

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/CommunityUtilService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/CommunityUtilService.java
@@ -11,6 +11,8 @@ import dutchiepay.backend.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class CommunityUtilService {
@@ -34,13 +36,14 @@ public class CommunityUtilService {
     // 게시글 작성 시 Free 객체 생성 후 저장
     public Free saveFree(User user, CreateFreeRequestDto createFreeRequestDto, String description) {
 
+        List<String> images = createFreeRequestDto.getImages();
         return freeRepository.save(Free.builder()
                 .user(user)
                 .title(createFreeRequestDto.getTitle())
                 .contents(createFreeRequestDto.getContent())
                 .category(createFreeRequestDto.getCategory())
                 .thumbnail(createFreeRequestDto.getThumbnail())
-                .images(String.join(",", createFreeRequestDto.getImages()))
+                .images(images.isEmpty() ? null : String.join(",", images))
                 .description(description.substring(0, Math.min(description.length(), 100)))
                 .build());
     }
@@ -60,7 +63,8 @@ public class CommunityUtilService {
     // 게시글 수정
     public void updatePost(User user, UpdateFreeRequestDto updateFreeRequestDto, String description) {
         Free free = validatePostAndWriter(user, updateFreeRequestDto.getFreeId());
-        free.updateFree(updateFreeRequestDto, description, String.join(",", updateFreeRequestDto.getImages()));
+        List<String> images = updateFreeRequestDto.getImages();
+        free.updateFree(updateFreeRequestDto, description, images == null? null : String.join(",", images));
     }
 
     // 댓글 길이 검증

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
@@ -104,7 +104,7 @@ public class MartService {
     public void changeStatus(ChangeStatusRequestDto req) {
         Share share = shareRepository.findById(req.getPostId())
                 .orElseThrow(() -> new CommunityException(CommunityErrorCode.INVALID_POST));
-
+        if (share.getState().equals("모집완료")) throw new CommunityException(CommunityErrorCode.ALREADY_DONE);
         share.changeStatus(req.getStatus());
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/PurchaseService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/PurchaseService.java
@@ -56,7 +56,8 @@ public class PurchaseService {
     @Transactional
     public Map<String, Long> createPurchase(User user, CreatePurchaseRequestDto requestDto) {
         if (requestDto.getTitle().length() > 60) throw new CommunityException(CommunityErrorCode.OVER_TITLE_LENGTH);
-        if (!(requestDto.getCategory().equals("share") || requestDto.getCategory().equals("trade")))
+        String category = requestDto.getCategory();
+        if (!(category.equals("share") || category.equals("trade")))
             throw new CommunityException(CommunityErrorCode.INVALID_CATEGORY);
         List<String> images = requestDto.getImages();
 
@@ -64,7 +65,7 @@ public class PurchaseService {
                 purchaseRepository.save(Purchase.builder().user(user)
                         .title(requestDto.getTitle())
                         .contents(requestDto.getContent())
-                        .price(requestDto.getPrice())
+                        .price(category.equals("share")? -1 : requestDto.getPrice())
                         .meetingPlace(requestDto.getMeetingPlace())
                         .latitude(requestDto.getLatitude())
                         .longitude(requestDto.getLongitude())
@@ -73,7 +74,7 @@ public class PurchaseService {
                         .images(images.isEmpty() ? null : String.join(",", images))
                         .category(requestDto.getCategory())
                         .location(user.getLocation())
-                        .state(requestDto.getCategory().equals("share")? "나눔중" : "거래중").build()).getPurchaseId());
+                        .state(category.equals("share")? "나눔중" : "거래중").build()).getPurchaseId());
     }
 
     /**

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/PurchaseService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/PurchaseService.java
@@ -119,11 +119,14 @@ public class PurchaseService {
 
     /**
      * 게시글 상태 변경
+     * 상태에 "완료" 글자가 있으면 예외 발생
      * @param req 게시글 Id와 변경할 상태가 담겨있는 dto
      */
+    @Transactional
     public void changeStatus(ChangeStatusRequestDto req) {
-        purchaseRepository.findById(req.getPostId())
-                .orElseThrow(() -> new CommunityException(CommunityErrorCode.CANNOT_FOUND_POST))
-                .changeState(req.getStatus());
+        Purchase purchase = purchaseRepository.findById(req.getPostId())
+                .orElseThrow(() -> new CommunityException(CommunityErrorCode.CANNOT_FOUND_POST));
+        if (purchase.getState().contains("완료")) throw new CommunityException(CommunityErrorCode.ALREADY_DONE);
+        purchase.changeState(req.getStatus());
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Purchase.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Purchase.java
@@ -72,12 +72,12 @@ public class Purchase extends Auditing {
     @Column(length = 1500)
     private String images;
 
-    public void updatePurchase(UpdatePurchaseRequestDto updateDto) {
+    public void updatePurchase(UpdatePurchaseRequestDto updateDto, String images) {
         this.title = updateDto.getTitle();
         this.contents = updateDto.getContent();
         this.price = updateDto.getPrice();
         this.category = updateDto.getCategory();
-        this.images = String.join(",", updateDto.getImages());
+        this.images = images;
         this.thumbnail = updateDto.getThumbnail();
         this.goods = updateDto.getGoods();
         this.latitude = updateDto.getLatitude();


### PR DESCRIPTION
### ⚡이슈 번호
resolve #215 

---
### ✅ PR 종류
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 게시글 상태 변경 카테고리 오류 시 발생하는 exception INVALID_CATEGORY -> INVALID_POST_TYPE 변경
- 이미 완료된 글 상태변경 시 예외 처리 추가
- 수정용 조회 api contents -> content 변수명 변경, thumbnail 누락 추가
- 게시글 리스트 조회 createdAt 오류 수정
- CommunityErrorCode - CANNOT_FOUND_POST 에러 메시지 "게시글을 찾을 수 없습니다"로 변경하여 통합
- 리스트 조회 시 비회원일 때 location으로 인한 오류 수정
- 나눔/거래 service에서 삭제되지 않은 게시글 검증 추가
- 나눔/거래, 자유 게시글 생성/수정 시 images가 null이면 ""로 저장되는 오류로 인해 null 검증 로직 추가
- 나눔/거래 category 검증 추가
- 나눔/거래 state 검증 추가
- 완료된 게시글은 수정하지 못하도록 변경
---
### 📖 참고 사항
