### PR TITLE
채팅방 구독 시 메시지 전달 url 변경 /  채팅방 메시지 목록 조회 기능 추가

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/controller/ChatController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/controller/ChatController.java
@@ -67,4 +67,11 @@ public class ChatController {
     public ResponseEntity<?> getChatRoomUsers(@RequestParam Long chatRoomId) {
         return ResponseEntity.ok(chatroomService.getChatRoomUsers(chatRoomId));
     }
+
+    @Operation(summary = "채팅방 메시지 목록 조회")
+    @GetMapping("/message")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getChatRoomMessages(@RequestParam Long chatRoomId) {
+        return ResponseEntity.ok(chatroomService.getChatRoomMessages(chatRoomId));
+    }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/dto/GetMessageListResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/dto/GetMessageListResponseDto.java
@@ -1,0 +1,18 @@
+package dutchiepay.backend.domain.chat.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetMessageListResponseDto {
+    private Long messageId;
+    private String content;
+    private String date;
+    private String sendAt;
+    private Long senderId;
+    private String senderName;
+    private String senderProfileImg;
+    private String type;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/ChatRoomRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/ChatRoomRepository.java
@@ -3,6 +3,6 @@ package dutchiepay.backend.domain.chat.repository;
 import dutchiepay.backend.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, QChatRoomRepository {
     ChatRoom findByPostIdAndType(Long postId, String type);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QChatRoomRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QChatRoomRepository.java
@@ -1,0 +1,9 @@
+package dutchiepay.backend.domain.chat.repository;
+
+import dutchiepay.backend.domain.chat.dto.GetMessageListResponseDto;
+
+import java.util.List;
+
+public interface QChatRoomRepository {
+    List<GetMessageListResponseDto> findChatRoomMessages(Long chatRoomId);
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QChatRoomRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QChatRoomRepositoryImpl.java
@@ -1,0 +1,66 @@
+package dutchiepay.backend.domain.chat.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dutchiepay.backend.domain.chat.dto.GetMessageListResponseDto;
+import dutchiepay.backend.entity.QMessage;
+import dutchiepay.backend.entity.QUser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class QChatRoomRepositoryImpl implements QChatRoomRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    QMessage message = QMessage.message;
+    QUser user = QUser.user;
+
+
+    @Override
+    public List<GetMessageListResponseDto> findChatRoomMessages(Long chatRoomId) {
+        List<Tuple> tuple = jpaQueryFactory
+                .select(message.messageId,
+                        message.content,
+                        message.date,
+                        message.time,
+                        message.senderId,
+                        user.nickname,
+                        user.profileImg,
+                        message.type)
+                .from(message)
+                .leftJoin(user).on(user.userId.eq(message.senderId))
+                .where(message.chatroom.chatroomId.eq(chatRoomId))
+                .orderBy(message.date.asc(), message.time.asc())
+                .fetch();
+
+        List<GetMessageListResponseDto> result = new ArrayList<>();
+
+        for (Tuple t : tuple) {
+            String date = t.get(message.date);
+            String formatDate = date.replace("년 ", "-")
+                    .replace("월 ", "-")
+                    .replace("일", "");
+
+            GetMessageListResponseDto dto = GetMessageListResponseDto.builder()
+                    .messageId(t.get(message.messageId))
+                    .content(t.get(message.content))
+                    .date(formatDate)
+                    .sendAt(t.get(message.time))
+                    .senderId(t.get(message.senderId))
+                    .senderName(t.get(user.nickname))
+                    .senderProfileImg(t.get(user.profileImg))
+                    .type(t.get(message.type))
+                    .build();
+
+            result.add(dto);
+        }
+
+        return result;
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
@@ -177,7 +177,7 @@ public class ChatRoomService {
         // 추후 상황에 맞게 isSendActivated를 변경한다.
         ChatRoomInfoResponse chatRoomInfo = ChatRoomInfoResponse.from(Long.valueOf(userId), chatRoom, true);
 
-        simpMessagingTemplate.convertAndSend("/sub/chatRoomId=" + chatRoomId, chatRoomInfo);
+        simpMessagingTemplate.convertAndSend("/sub/chat/" + chatRoomId, chatRoomInfo);
     }
 
     /**

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
@@ -250,6 +250,10 @@ public class ChatRoomService {
     public List<GetChatRoomUsersResponseDto> getChatRoomUsers(Long chatRoomId) {
         return userChatroomService.getChatRoomUsers(chatRoomId);
     }
+
+    public List<GetMessageListResponseDto> getChatRoomMessages(Long chatRoomId) {
+        return chatRoomRepository.findChatRoomMessages(chatRoomId);
+    }
 //
 //    public List<MessageResponse> getChatRoomMessageList(User user, Long chatRoomId) {
 //        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)


### PR DESCRIPTION
### ⚡이슈 번호
resolve #222 

---
### ✅ PR 종류
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 채팅방 구독 시에 채팅방 정보에 관한 데이터를 보내주는 주소가 잘못 작성되어 있어 변경했습니다
- 우선적으로 클라이언트와의 연결을 위해 채팅방의 모든 메시지를 보내주는 api를 추가했습니다.
---
### 📖 참고 사항
