### PR TITLE
게시글/알림 관련 이슈 확인(내가 작성한 게시글, 알림)

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/community/service/MartService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
+
 @Service
 @RequiredArgsConstructor
 public class MartService {
@@ -81,7 +83,7 @@ public class MartService {
                 .description(description)
                 .thumbnail(req.getThumbnail())
                 .category(req.getCategory())
-                .images(String.join(",", req.getImages()))
+                .images(req.getImages().length == 0 ? null : String.join(",", req.getImages()))
                 .now(1)
                 .hits(0)
                 .build();

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/repository/QNoticeRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/notice/repository/QNoticeRepositoryImpl.java
@@ -41,7 +41,7 @@ public class QNoticeRepositoryImpl implements QNoticeRepository{
                                         subNotice.user.eq(user),
                                         subNotice.origin.eq(notice.origin),
                                         subNotice.type.eq(notice.type),
-                                        subNotice.isRead.eq(false),
+//                                        subNotice.isRead.eq(false),
                                         subNotice.createdAt.goe(LocalDateTime.now().minusDays(7)),
                                         subNotice.deletedAt.isNull()
                                 )
@@ -60,7 +60,7 @@ public class QNoticeRepositoryImpl implements QNoticeRepository{
                             notice.user.eq(user),
                             notice.origin.eq(n.getOrigin()),
                             notice.type.eq(n.getType()),
-                            notice.isRead.eq(false),
+//                            notice.isRead.eq(false),
                             notice.createdAt.goe(LocalDateTime.now().minusDays(7)),
                             notice.deletedAt.isNull()
                     )
@@ -96,9 +96,11 @@ public class QNoticeRepositoryImpl implements QNoticeRepository{
         List<Notice> notices = jpaQueryFactory
                 .selectFrom(notice)
                 .where(
-                        notice.origin.eq(origin)
-                                .and(notice.isRead.eq(false))
-                                .and(notice.user.eq(user))
+                        notice.origin.eq(origin),
+//                                .and(notice.isRead.eq(false))
+                        notice.user.eq(user),
+                        notice.createdAt.goe(LocalDateTime.now().minusDays(7)),
+                        notice.deletedAt.isNull()
                 )
                 .orderBy(notice.noticeId.desc())
                 .fetch();

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
@@ -380,9 +380,6 @@ public class QProfileRepositoryImpl implements QProfileRepository {
 
         List<MyPostsResponseDto.Post> result = new ArrayList<>();
         for (Tuple tuple : queryResult) {
-            System.out.println("===========================================");
-            System.out.println("tuple = " + tuple);
-            System.out.println("===========================================");
             LocalDateTime dbTime = tuple.get(free.createdAt);
 
             long daysBetween = ChronoUnit.DAYS.between(dbTime, LocalDateTime.now());

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
@@ -364,7 +364,7 @@ public class QProfileRepositoryImpl implements QProfileRepository {
                 .from(free)
                 .leftJoin(free.user)
                 .leftJoin(comment).on(comment.free.eq(free).and(comment.deletedAt.isNull()))
-                .where(comment.user.eq(user))
+                .where(comment.user.eq(user).and(free.deletedAt.isNull()))
                 .groupBy(free.freeId)
                 .orderBy(free.createdAt.desc())
                 .offset(pageable.getOffset())

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
@@ -274,7 +274,7 @@ public class QProfileRepositoryImpl implements QProfileRepository {
                 "share.description as content, " +
                 "'마트/배달' as category, " +
                 "NULL as commentCount, " +
-                "share.thumbnail, " +
+                "share.thumbnail as thumbnail, " +
                 "users.nickname as writerNickname, " +
                 "users.profile_img as writerProfileImage " +
                 "FROM share " +
@@ -288,7 +288,7 @@ public class QProfileRepositoryImpl implements QProfileRepository {
                 "free.description as content, " +
                 "'자유' as category, " +
                 "(SELECT COUNT(*) FROM comment WHERE free_id = free.free_id AND deleted_at IS NULL) as commentCount, " +
-                "NULL as thumbnail, " +
+                "free.thumbnail as thumbnail, " +
                 "users.nickname as writerNickname, " +
                 "users.profile_img as writerProfileImage " +
                 "FROM free " +

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/profile/repository/QProfileRepositoryImpl.java
@@ -272,7 +272,7 @@ public class QProfileRepositoryImpl implements QProfileRepository {
                 "share.title, " +
                 "share.created_at as writeTime, " +
                 "share.description as content, " +
-                "'마트/배달' as category, " +
+                "share.category as category, " +
                 "NULL as commentCount, " +
                 "share.thumbnail as thumbnail, " +
                 "users.nickname as writerNickname, " +
@@ -286,7 +286,7 @@ public class QProfileRepositoryImpl implements QProfileRepository {
                 "free.title, " +
                 "free.created_at as writeTime, " +
                 "free.description as content, " +
-                "'자유' as category, " +
+                "free.category as category, " +
                 "(SELECT COUNT(*) FROM comment WHERE free_id = free.free_id AND deleted_at IS NULL) as commentCount, " +
                 "free.thumbnail as thumbnail, " +
                 "users.nickname as writerNickname, " +

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/ChatRoom.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/ChatRoom.java
@@ -19,7 +19,6 @@ public class ChatRoom extends Auditing {
     @Column(nullable = false)
     private String chatRoomName;
 
-    @Column(nullable = false)
     private String chatRoomImg;
 
     @Column(nullable = false)


### PR DESCRIPTION
### ⚡이슈 번호
resolve #226

---
### ✅ PR 종류
- [ ] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 마트/배달 게시글 작성 시 이미지 length 0 일 경우 null로 저장하도록 변경
- 내가 작성한 게시글 확인 시 자유게시글 썸네일 데이터 반환하도록 변경
- 채팅방 이미지가 null인 경우가 가능하여 컬럼 nullable하게 변경
- 알림 7일 이내 데이터는 읽음여부 상관없이 모두 return하도록 변경
- 작성 게시글/댓글 반환 시 모두 상세 카테고리 반환하도록 변경
- 삭제된 게시글의 경우 댓글 조회 시 포함하지 않도록 변경
---
### 📖 참고 사항
