### PR TITLE
공동구매 쿼리 개선

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/dto/GetBuyListResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/dto/GetBuyListResponseDto.java
@@ -2,6 +2,8 @@ package dutchiepay.backend.domain.commerce.dto;
 
 import lombok.*;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @Getter
@@ -21,7 +23,10 @@ public class GetBuyListResponseDto {
     }
 
     @Getter
+    @Setter
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class ProductDto {
         private Long buyId;
         private String productName;
@@ -35,6 +40,30 @@ public class GetBuyListResponseDto {
         private Boolean isLiked;
         private Double rating;
         private Long reviewCount;
+
+        public ProductDto(Long buyId, String productName, String productImg, Integer productPrice, Integer discountPrice,
+                          Integer discountPercent, Integer skeleton, Integer nowCount, LocalDate deadline, Boolean isLiked) {
+            this.buyId = buyId;
+            this.productName = productName;
+            this.productImg = productImg;
+            this.productPrice = productPrice;
+            this.discountPrice = discountPrice;
+            this.discountPercent = discountPercent;
+            this.skeleton = skeleton;
+            this.nowCount = nowCount;
+            this.expireDate = calculateExpireDate(deadline);
+            this.isLiked = isLiked;
+        }
+
+        private int calculateExpireDate(LocalDate deadline) {
+            if (deadline.isBefore(LocalDate.now())) {
+                return -1;
+            } else if (deadline.isEqual(LocalDate.now())) {
+                return 0;
+            } else {
+                return (int) ChronoUnit.DAYS.between(LocalDate.now(), deadline);
+            }
+        }
     }
 }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/dto/OrderAndCursorCondition.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/commerce/dto/OrderAndCursorCondition.java
@@ -1,0 +1,15 @@
+package dutchiepay.backend.domain.commerce.dto;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@Getter
+@AllArgsConstructor
+public class OrderAndCursorCondition {
+    private OrderSpecifier[] orderBy;
+    private BooleanBuilder cursorCondition;
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Buy.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Buy.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Builder
@@ -21,6 +23,14 @@ public class Buy extends Auditing {
     @OneToOne
     @JoinColumn(name = "product_id")
     private Product product;
+
+    @OneToMany(mappedBy = "buy")
+    @Builder.Default
+    private List<Like> likes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "buy")
+    @Builder.Default
+    private List<BuyCategory> buyCategories = new ArrayList<>();
 
     // 제목
     @Column(nullable = false, length = 50)

--- a/DutchiePay/src/main/java/dutchiepay/backend/entity/Category.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/entity/Category.java
@@ -4,6 +4,8 @@ import dutchiepay.backend.global.config.Auditing;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.List;
+
 @Entity
 @Builder
 @Table(name = "Category")
@@ -15,6 +17,9 @@ public class Category extends Auditing {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long categoryId;
+
+    @OneToMany(mappedBy = "category")
+    private List<BuyCategory> buyCategories;
 
     @Column(nullable = false)
     private String name;


### PR DESCRIPTION
### ⚡이슈 번호
resolve #228 

---
### ✅ PR 종류
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 기존 공동구매 쿼리의 경우 데이터가 많아질 수록 성능이 엄청나게 저하되는 현상이 있었습니다.
> 100건 기준 : 351ms
> 100만건 기준 : 3733ms

이유는 다음 과 같습니다.
<img width="809" alt="스크린샷 2025-01-09 오후 2 31 38" src="https://github.com/user-attachments/assets/c1139d5e-1e5c-441f-b67c-84ffc6238adc" />

- 기존 쿼리의 경우 한개의 쿼리로 모두 처리하려고 하다 보니, 각 buy들에 대한 리뷰 데이터까지 전부 조회를 한 이후에 limi을 이용해 16개로 자르고 있었습니다.
이 경우 데이터가 100건의 경우 100개 상품에 대해 리뷰를 조회하면 되지만, 100만건의 경우 100만건에 해당하는 상품의 리뷰를 전부 조회해야 하기 때문에 성능이 저하되는 것으로 판단되었습니다.
또한 불필요한 left join이 다수 있어 이를 제거하고 필요한 join만 추가하였습니다.

---
### 📖 참고 사항
