### PR TITLE
채팅방 에러 수정 및 Redis 저장소 적용

### DIFF
--- a/DutchiePay/build.gradle
+++ b/DutchiePay/build.gradle
@@ -73,6 +73,8 @@ dependencies {
 
     // Test용 DB 사용
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.2'
 }
 
 tasks.named('test') {

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/ChronoUtil.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/ChronoUtil.java
@@ -46,6 +46,10 @@ public class ChronoUtil {
     }
 
     public static String formatChatTime(String date, String time) {
+        if (date == null || time == null) {
+            return null;
+        }
+
         DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일");
 
         LocalDate messageDate = LocalDate.parse(date, dateFormatter);

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QUserChatRoomRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QUserChatRoomRepositoryImpl.java
@@ -75,7 +75,7 @@ public class QUserChatRoomRepositoryImpl implements QUserChatRoomRepository {
                     .chatImg(tuple.get(chatRoom.chatRoomImg))
                     .chatUser(tuple.get(3, Long.class).intValue())
                     .unreadCount(tuple.get(4, Long.class).intValue())
-                    .lastMsg(tuple.get(message.type).equals("image") ? "이미지를 전송했습니다." : tuple.get(message.content))
+                    .lastMsg("img".equals(tuple.get(message.type)) ? "이미지를 전송했습니다." : tuple.get(message.content))
                     .lastChatTime(ChronoUtil.formatChatTime(tuple.get(message.date), tuple.get(message.time)))
                     .type(tuple.get(chatRoom.type))
                     .build();

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
@@ -76,7 +76,7 @@ public class ChatRoomService {
         }
         // 유저가 이미 채팅방에 속해있는 지 검증
         if (userChatroomService.alreadyJoined(user, chatRoom)) {
-            throw new ChatException(ChatErrorCode.ALREADY_JOINED);
+            return JoinChatRoomResponseDto.of(chatRoom.getChatroomId());
         }
 
         // 채팅방의 인원이 가득 찼을 경우 예외처리

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
@@ -203,7 +203,6 @@ public class ChatRoomService {
                 .date(message.getDate())
                 .time(message.getTime())
                 .unreadCount(chatRoom.getNowPartInc() - getSubscribedUserCount(chatRoomId))
-//                .unreadCount(0)
                 .build();
 
         messageRepository.save(newMessage);
@@ -260,20 +259,6 @@ public class ChatRoomService {
         redisMessageService.getMessageFromMemory(chatRoomId, 1);
         return chatRoomRepository.findChatRoomMessages(chatRoomId);
     }
-//
-//    public List<MessageResponse> getChatRoomMessageList(User user, Long chatRoomId) {
-//        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-//                .orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
-//
-//        List<Message> messageList = messageRepository.findAllByChatroom(chatRoom);
-//        List<MessageResponse> dto = new ArrayList<>();
-//
-//        for (Message message : messageList) {
-//            dto.add(MessageResponse.of(message));
-//        }
-//
-//        return dto;
-//    }
 
 //    public void checkCursorId(Long chatRoomId, Long userId) {
 //        Long cursor = messageRepository.findCursorId(chatRoomId, userId);
@@ -293,7 +278,7 @@ public class ChatRoomService {
         for (SimpUser user : simpUserRegistry.getUsers()) {
             for (SimpSession session : user.getSessions()) {
                 for (SimpSubscription subscription : session.getSubscriptions()) {
-                    if (subscription.getDestination().equals("/sub/chat/room/" + chatRoomId)) {
+                    if (subscription.getDestination().equals("/sub/chat/" + chatRoomId)) {
                         userIds.add(Long.parseLong(user.getName()));
                     }
                 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/MessageService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/MessageService.java
@@ -1,5 +1,7 @@
 package dutchiepay.backend.domain.chat.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import dutchiepay.backend.domain.chat.dto.MessageResponse;
 import dutchiepay.backend.domain.chat.repository.MessageRepository;
 import dutchiepay.backend.entity.ChatRoom;
@@ -7,6 +9,8 @@ import dutchiepay.backend.entity.Message;
 import dutchiepay.backend.entity.User;
 import dutchiepay.backend.entity.UserChatRoom;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
@@ -14,9 +18,13 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MessageService {
     private static final String CHAT_ROOM_PREFIX = "/sub/chat/";
     private final SimpMessagingTemplate simpMessagingTemplate;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/RedisMessageService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/RedisMessageService.java
@@ -36,7 +36,6 @@ public class RedisMessageService {
         Set<Object> objects = redisTemplate.opsForZSet().range(redisKey, start, end);
         for (Object obj : objects) {
             MessageResponse mr = (MessageResponse) obj;
-            log.info("mr: {}", mr.getContent());
         }
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/RedisMessageService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/RedisMessageService.java
@@ -1,0 +1,42 @@
+package dutchiepay.backend.domain.chat.service;
+
+import dutchiepay.backend.domain.chat.dto.MessageResponse;
+import dutchiepay.backend.entity.Message;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisMessageService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // Redis key 형식: chat:{chatRoomId}:messages:yyMMdd
+    private static final String CHAT_KEY_PREFIX = "chat:";
+    private static final String MESSAGES_SUFFIX = ":messages:";
+
+    public void saveMessage(String chatRoomId, Message message) {
+        String redisKey = CHAT_KEY_PREFIX + chatRoomId + MESSAGES_SUFFIX + message.getDate().replaceAll("[^0-9]", "");
+        redisTemplate.opsForZSet().add(redisKey, MessageResponse.of(message), message.getMessageId());
+    }
+
+    public void getMessageFromMemory(Long chatRoomId, int page) {
+        String redisKey = CHAT_KEY_PREFIX + chatRoomId + MESSAGES_SUFFIX + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        int pageSize = 10;
+        int start = (page - 1) * pageSize;
+        int end = start + pageSize - 1;
+
+        Set<Object> objects = redisTemplate.opsForZSet().range(redisKey, start, end);
+        for (Object obj : objects) {
+            MessageResponse mr = (MessageResponse) obj;
+            log.info("mr: {}", mr.getContent());
+        }
+    }
+}

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/UserChatroomService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/UserChatroomService.java
@@ -77,4 +77,8 @@ public class UserChatroomService {
     public List<GetChatRoomUsersResponseDto> getChatRoomUsers(Long chatRoomId) {
         return userChatroomRepository.getChatRoomUsers(chatRoomId);
     }
+
+    public void updateLastMessageToAllSubscribers(List<Long> userIds, long l, Long messageId) {
+        userChatroomRepository.updateLastMessageToAllSubscribers(userIds, l, messageId);
+    }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/config/Auditing.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/config/Auditing.java
@@ -1,5 +1,10 @@
 package dutchiepay.backend.global.config;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
@@ -16,12 +21,21 @@ import java.time.LocalDateTime;
 public abstract class Auditing {
     @CreatedDate
     @Column(nullable = false, updatable = false)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(shape= JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm")
     private LocalDateTime createdAt;
 
     @LastModifiedDate
     @Column(nullable = false)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(shape= JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm")
     private LocalDateTime updatedAt;
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(shape= JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm")
     private LocalDateTime deletedAt;
 
     public void delete(){

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/config/RedisConfig.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/config/RedisConfig.java
@@ -1,9 +1,7 @@
 package dutchiepay.backend.global.config;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -43,22 +41,15 @@ public class RedisConfig {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
 
+        GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer();
+
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
-        objectMapper.activateDefaultTyping(
-                objectMapper.getPolymorphicTypeValidator(),
-                ObjectMapper.DefaultTyping.NON_FINAL,
-                JsonTypeInfo.As.PROPERTY
-        );
+        redisTemplate.setValueSerializer(jsonSerializer);
+        redisTemplate.setHashValueSerializer(jsonSerializer);
 
-        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
-
-        redisTemplate.setValueSerializer(serializer);
-        redisTemplate.setHashValueSerializer(serializer);
-
+        redisTemplate.afterPropertiesSet();
         return redisTemplate;
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/config/RedisConfig.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/config/RedisConfig.java
@@ -1,5 +1,9 @@
 package dutchiepay.backend.global.config;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -8,6 +12,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @EnableCaching
@@ -37,8 +42,23 @@ public class RedisConfig {
     public RedisTemplate<String, Object> redisTemplate() {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
+        objectMapper.activateDefaultTyping(
+                objectMapper.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        redisTemplate.setValueSerializer(serializer);
+        redisTemplate.setHashValueSerializer(serializer);
+
         return redisTemplate;
     }
 }


### PR DESCRIPTION
### ⚡이슈 번호
resolve #230 

---
### ✅ PR 종류
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- RDB만을 이용하여 채팅 메시지를 관리하게 되면 조금만 복잡해져도 성능상의 문제가 있다고 하여 최근 7일간의 데이터의 경우 Redis 저장소를 이용하여 저장하고 그 이전의 데이터는 RDB를 사용하는 것으로 변경하고자 합니다.
- Sorted Set을 이용해서 저장하여, 페이징기능처럼 데이터를 잘라서 보내는 것도 가능할 것으로 생각됩니다.
- 메시지 데이터에서 date와 time이 null일 경우 ChronoUtil에서 null을 return하도록 변경하였습니다.
- 유저가 이미 채팅방에 참여되어있는 경우 에러 메시지가 아닌 채팅방 Id를 바로 return하여 채팅방으로 바로 이동하도록 변경했습니다.
---
### 📖 참고 사항
