### PR TITLE
채팅 메시지 조회 무한스크롤 기능 적용

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/controller/ChatController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/controller/ChatController.java
@@ -71,7 +71,9 @@ public class ChatController {
     @Operation(summary = "채팅방 메시지 목록 조회")
     @GetMapping("/message")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<?> getChatRoomMessages(@RequestParam Long chatRoomId) {
-        return ResponseEntity.ok(chatroomService.getChatRoomMessages(chatRoomId));
+    public ResponseEntity<?> getChatRoomMessages(@RequestParam(value = "chatRoomId") Long chatRoomId,
+                                                 @RequestParam(value = "cursor", required = false) String cursor,
+                                                 @RequestParam(value = "limit") Long limit) {
+        return ResponseEntity.ok(chatroomService.getChatRoomMessages(chatRoomId, cursor, limit));
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/dto/GetMessageListResponseDto.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/dto/GetMessageListResponseDto.java
@@ -2,17 +2,13 @@ package dutchiepay.backend.domain.chat.dto;
 
 import lombok.*;
 
+import java.util.List;
+
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GetMessageListResponseDto {
-    private Long messageId;
-    private String content;
-    private String date;
-    private String sendAt;
-    private Long senderId;
-    private String senderName;
-    private String senderProfileImg;
-    private String type;
+    private List<MessageResponse> messages;
+    private String cursor;
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/dto/MessageResponse.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/dto/MessageResponse.java
@@ -12,6 +12,7 @@ public class MessageResponse {
     private Long sender;
     private String content;
     private Integer unreadCount;
+    private String type;
 
     public static MessageResponse of(Message message) {
         return MessageResponse.builder()
@@ -19,6 +20,7 @@ public class MessageResponse {
                 .sender(message.getSenderId())
                 .content(message.getContent())
                 .unreadCount(message.getUnreadCount())
+                .type(message.getType())
                 .build();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/dto/MessageResponse.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/dto/MessageResponse.java
@@ -9,18 +9,22 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MessageResponse {
     private Long messageId;
-    private Long sender;
+    private Long senderId;
+    private String type;
     private String content;
     private Integer unreadCount;
-    private String type;
+    private String date;
+    private String time;
 
     public static MessageResponse of(Message message) {
         return MessageResponse.builder()
                 .messageId(message.getMessageId())
-                .sender(message.getSenderId())
+                .senderId(message.getSenderId())
+                .type(message.getType())
                 .content(message.getContent())
                 .unreadCount(message.getUnreadCount())
-                .type(message.getType())
+                .date(message.getDate())
+                .time(message.getTime())
                 .build();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/exception/ChatErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/exception/ChatErrorCode.java
@@ -18,12 +18,13 @@ public enum ChatErrorCode implements StatusCode {
     INVALID_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 타입입니다."),
     MANAGER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "방장은 채팅방을 나갈 수 없습니다."),
     ALREADY_JOINED(HttpStatus.BAD_REQUEST, "이미 채팅방에 참여되어있습니다."),
+    EMPTY_MESSAGE(HttpStatus.BAD_REQUEST, "채팅방에 메시지가 존재하지 않습니다."),
 
     /**
      * 403 Forbidden
      */
     USER_BANNED(HttpStatus.FORBIDDEN, "사용자가 채팅방에서 차단되었습니다."),
-    NOT_MANAGER(HttpStatus.FORBIDDEN, "방장 권한이 없습니다."),;
+    NOT_MANAGER(HttpStatus.FORBIDDEN, "방장 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/exception/ChatErrorCode.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/exception/ChatErrorCode.java
@@ -18,7 +18,7 @@ public enum ChatErrorCode implements StatusCode {
     INVALID_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 타입입니다."),
     MANAGER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "방장은 채팅방을 나갈 수 없습니다."),
     ALREADY_JOINED(HttpStatus.BAD_REQUEST, "이미 채팅방에 참여되어있습니다."),
-    EMPTY_MESSAGE(HttpStatus.BAD_REQUEST, "채팅방에 메시지가 존재하지 않습니다."),
+    EMPTY_MESSAGE(HttpStatus.BAD_REQUEST, "더 이상 불러올 메시지가 없습니다."),
 
     /**
      * 403 Forbidden

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QChatRoomRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QChatRoomRepository.java
@@ -5,5 +5,5 @@ import dutchiepay.backend.domain.chat.dto.GetMessageListResponseDto;
 import java.util.List;
 
 public interface QChatRoomRepository {
-    List<GetMessageListResponseDto> findChatRoomMessages(Long chatRoomId);
+    GetMessageListResponseDto findChatRoomMessages(Long chatRoomId, String cursorDate, Long cursorMessageId, Long limit);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QChatRoomRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QChatRoomRepositoryImpl.java
@@ -23,7 +23,7 @@ public class QChatRoomRepositoryImpl implements QChatRoomRepository {
 
 
     @Override
-    public List<GetMessageListResponseDto> findChatRoomMessages(Long chatRoomId) {
+    public GetMessageListResponseDto findChatRoomMessages(Long chatRoomId, String cursorDate, Long cursorMessageId, Long limit) {
         List<Tuple> tuple = jpaQueryFactory
                 .select(message.messageId,
                         message.content,
@@ -47,20 +47,20 @@ public class QChatRoomRepositoryImpl implements QChatRoomRepository {
                     .replace("월 ", "-")
                     .replace("일", "");
 
-            GetMessageListResponseDto dto = GetMessageListResponseDto.builder()
-                    .messageId(t.get(message.messageId))
-                    .content(t.get(message.content))
-                    .date(formatDate)
-                    .sendAt(t.get(message.time))
-                    .senderId(t.get(message.senderId))
-                    .senderName(t.get(user.nickname))
-                    .senderProfileImg(t.get(user.profileImg))
-                    .type(t.get(message.type))
-                    .build();
+//            GetMessageListResponseDto dto = GetMessageListResponseDto.builder()
+//                    .messageId(t.get(message.messageId))
+//                    .content(t.get(message.content))
+//                    .date(formatDate)
+//                    .sendAt(t.get(message.time))
+//                    .senderId(t.get(message.senderId))
+//                    .senderName(t.get(user.nickname))
+//                    .senderProfileImg(t.get(user.profileImg))
+//                    .type(t.get(message.type))
+//                    .build();
 
-            result.add(dto);
+//            result.add(dto);
         }
 
-        return result;
+        return null;
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QChatRoomRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QChatRoomRepositoryImpl.java
@@ -3,12 +3,17 @@ package dutchiepay.backend.domain.chat.repository;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import dutchiepay.backend.domain.chat.dto.GetMessageListResponseDto;
+import dutchiepay.backend.domain.chat.dto.MessageResponse;
+import dutchiepay.backend.domain.chat.exception.ChatErrorCode;
+import dutchiepay.backend.domain.chat.exception.ChatException;
 import dutchiepay.backend.entity.QMessage;
 import dutchiepay.backend.entity.QUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,48 +24,59 @@ public class QChatRoomRepositoryImpl implements QChatRoomRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     QMessage message = QMessage.message;
-    QUser user = QUser.user;
-
 
     @Override
     public GetMessageListResponseDto findChatRoomMessages(Long chatRoomId, String cursorDate, Long cursorMessageId, Long limit) {
+        cursorMessageId = cursorMessageId == null ? Long.MAX_VALUE : cursorMessageId;
+
         List<Tuple> tuple = jpaQueryFactory
                 .select(message.messageId,
                         message.content,
                         message.date,
                         message.time,
                         message.senderId,
-                        user.nickname,
-                        user.profileImg,
                         message.type)
                 .from(message)
-                .leftJoin(user).on(user.userId.eq(message.senderId))
                 .where(message.chatroom.chatroomId.eq(chatRoomId))
-                .orderBy(message.date.asc(), message.time.asc())
+                .where(message.date.loe(cursorDate).and(message.messageId.loe(cursorMessageId)))
+                .orderBy(message.messageId.desc())
+                .limit(limit + 1)
                 .fetch();
 
-        List<GetMessageListResponseDto> result = new ArrayList<>();
+        if (tuple.isEmpty()) {
+            throw new ChatException(ChatErrorCode.EMPTY_MESSAGE);
+        }
 
+        List<MessageResponse> result = new ArrayList<>();
+
+        int count = 0;
         for (Tuple t : tuple) {
+            if (count >= limit) {
+                break;
+            }
+
             String date = t.get(message.date);
             String formatDate = date.replace("년 ", "-")
                     .replace("월 ", "-")
                     .replace("일", "");
 
-//            GetMessageListResponseDto dto = GetMessageListResponseDto.builder()
-//                    .messageId(t.get(message.messageId))
-//                    .content(t.get(message.content))
-//                    .date(formatDate)
-//                    .sendAt(t.get(message.time))
-//                    .senderId(t.get(message.senderId))
-//                    .senderName(t.get(user.nickname))
-//                    .senderProfileImg(t.get(user.profileImg))
-//                    .type(t.get(message.type))
-//                    .build();
+            MessageResponse dto = MessageResponse.builder()
+                    .messageId(t.get(message.messageId))
+                    .content(t.get(message.content))
+                    .date(formatDate)
+                    .time(t.get(message.time))
+                    .senderId(t.get(message.senderId))
+                    .type(t.get(message.type))
+                    .build();
 
-//            result.add(dto);
+            result.add(dto);
+            count++;
         }
 
-        return null;
+        String nextCursor = tuple.size() > limit ? tuple.get(limit.intValue()).get(message.date) + tuple.get(limit.intValue()).get(message.messageId) : null;
+        return GetMessageListResponseDto.builder()
+                .messages(result)
+                .cursor(nextCursor)
+                .build();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
@@ -205,7 +205,7 @@ public class ChatRoomService {
                 .type(message.getType())
                 .senderId(message.getSenderId())
                 .content(message.getContent())
-                .date(message.getDate())
+                .date(LocalDate.parse(message.getDate(), DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")).format(DateTimeFormatter.ofPattern("yyyyMMdd")))
                 .time(message.getTime())
                 .unreadCount(chatRoom.getNowPartInc() - getSubscribedUserCount(chatRoomId))
                 .build();

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
@@ -268,7 +268,7 @@ public class ChatRoomService {
             cursorDate = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
         } else {
             cursorDate = cursor.substring(0, 8);
-            cursorMessageId = Long.valueOf(cursor.substring(8));
+            cursorMessageId = Long.parseLong(cursor.substring(8)) != 0 ? Long.parseLong(cursor.substring(8)) : null;
         }
 
         LocalDate currentDate = LocalDate.now();
@@ -278,17 +278,14 @@ public class ChatRoomService {
         long daysDifference = ChronoUnit.DAYS.between(requestDate, currentDate);
 
         if (daysDifference <= 7) {
-            // Redis에서 먼저 조회 시도
             GetMessageListResponseDto redisMessages =
                     redisMessageService.getMessageFromMemory(chatRoomId, cursorDate, cursorMessageId, limit);
 
-            // Redis에 데이터가 있으면 사용, 없으면 DB에서 조회
             if (redisMessages != null) {
                 return redisMessages;
             }
         }
 
-        // 7일 이전 데이터이거나 Redis에 데이터가 없는 경우 DB 조회
         return chatRoomRepository.findChatRoomMessages(chatRoomId, cursorDate, cursorMessageId, limit);
     }
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/MessageService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/MessageService.java
@@ -51,8 +51,8 @@ public class MessageService {
                 .type("out")
                 .senderId(ucr.getUser().getUserId())
                 .content(ucr.getUser().getNickname() + "님이 퇴장하셨습니다.")
-                .date(LocalDate.now().toString())
-                .time(LocalTime.now().toString())
+                .date(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")))
+                .time(LocalTime.now().format(DateTimeFormatter.ofPattern("a h:m").withLocale(Locale.KOREA)))
                 .build();
 
         messageRepository.save(leaveMessage);
@@ -66,8 +66,8 @@ public class MessageService {
                 .type("ban")
                 .senderId(target.getUser().getUserId())
                 .content(target.getUser().getNickname() + "님이 강퇴당하셨습니다.")
-                .date(LocalDate.now().toString())
-                .time(LocalTime.now().toString())
+                .date(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")))
+                .time(LocalTime.now().format(DateTimeFormatter.ofPattern("a h:m").withLocale(Locale.KOREA)))
                 .build();
 
         messageRepository.save(kickedMessage);

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/MessageService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/MessageService.java
@@ -36,7 +36,7 @@ public class MessageService {
                 .type("enter")
                 .senderId(user.getUserId())
                 .content(user.getNickname() + "님이 입장하셨습니다.")
-                .date(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")))
+                .date(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd")))
                 .time(LocalTime.now().format(DateTimeFormatter.ofPattern("a h:m").withLocale(Locale.KOREA)))
                 .build();
 
@@ -51,7 +51,7 @@ public class MessageService {
                 .type("out")
                 .senderId(ucr.getUser().getUserId())
                 .content(ucr.getUser().getNickname() + "님이 퇴장하셨습니다.")
-                .date(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")))
+                .date(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd")))
                 .time(LocalTime.now().format(DateTimeFormatter.ofPattern("a h:m").withLocale(Locale.KOREA)))
                 .build();
 
@@ -66,7 +66,7 @@ public class MessageService {
                 .type("ban")
                 .senderId(target.getUser().getUserId())
                 .content(target.getUser().getNickname() + "님이 강퇴당하셨습니다.")
-                .date(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")))
+                .date(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd")))
                 .time(LocalTime.now().format(DateTimeFormatter.ofPattern("a h:m").withLocale(Locale.KOREA)))
                 .build();
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/RedisMessageService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/RedisMessageService.java
@@ -22,7 +22,7 @@ import java.util.Set;
 public class RedisMessageService {
     private final RedisTemplate<String, Object> redisTemplate;
 
-    // Redis key 형식: chat:{chatRoomId}:messages:yyMMdd
+    // Redis key 형식: chat:{chatRoomId}:messages:yyyyMMdd
     private static final String CHAT_KEY_PREFIX = "chat:";
     private static final String MESSAGES_SUFFIX = ":messages:";
 
@@ -31,7 +31,8 @@ public class RedisMessageService {
         redisTemplate.opsForZSet().add(redisKey, MessageResponse.of(message), message.getMessageId());
     }
 
-    public GetMessageListResponseDto getMessageFromMemory(Long chatRoomId, String cursorDate, Long cursorMessageId, Long limit) {
+    public GetMessageListResponseDto
+    getMessageFromMemory(Long chatRoomId, String cursorDate, Long cursorMessageId, Long limit) {
         List<MessageResponse> totalDataList = new ArrayList<>();
         String nextCursor;
         Long remainingLimit = limit;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/RedisMessageService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/RedisMessageService.java
@@ -74,7 +74,17 @@ public class RedisMessageService {
             for (Object obj : messages) {
                 if (count < remainingLimit) {
                     MessageResponse mr = (MessageResponse) obj;
-                    totalDataList.add(mr);
+                    MessageResponse mr2 = MessageResponse.builder()
+                            .messageId(mr.getMessageId())
+                            .content(mr.getContent())
+                            .date(LocalDate.parse(mr.getDate(), DateTimeFormatter.ofPattern("yyyyMMdd"))
+                                    .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                            .time(mr.getTime())
+                            .senderId(mr.getSenderId())
+                            .type(mr.getType())
+                            .build();
+
+                    totalDataList.add(mr2);
                 } else {
                     MessageResponse lastMessage = (MessageResponse) obj;
                     nextCursor = currentDate + lastMessage.getMessageId();

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/RedisMessageService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/RedisMessageService.java
@@ -46,7 +46,7 @@ public class RedisMessageService {
         }
 
         if (messages == null || messages.isEmpty()) {
-            throw new ChatException(ChatErrorCode.EMPTY_MESSAGE);
+            return null;
         }
 
         List<MessageResponse> dataList = new ArrayList<>();


### PR DESCRIPTION
### ⚡이슈 번호
resolve #232 

---
### ✅ PR 종류
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 커서방식의 무한스크롤 방식을 Redis와 RDB 모두 적용하였습니다.
- 커서의 경우 가져와야할 데이터의 날짜(yyyyMMdd) + messageId 번호로 지정됩니다.
- 만약 커서의 messageId가 00일 경우 해당 날짜의 최신 데이터부터 가져오게 됩니다.
- queryDsl에서 date 비교를 위해 "yyyy년 MM월 dd일" 형식에서 "yyyyMMdd" 형식으로 변경하였습니다.
- Redis 저장소의 경우 해당 키값의 데이터가 limit의 개수보다 적을 경우 이전 데이터에서 추가로 데이터를 가져오게 작성되었습니다.
---
### 📖 참고 사항
