### PR TITLE
채팅방 읽지 않은 인원 수 적용 및 강퇴당한 채팅방 활성화되지 않게 변경

### DIFF
--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/controller/ChatController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/controller/ChatController.java
@@ -82,9 +82,8 @@ public class ChatController {
     @Operation(summary = "method 테스트")
     @GetMapping("/test")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<?> test(@RequestParam(value = "chatRoomId") Long chatRoomId,
-                                  @RequestParam(value = "cursorId", required = false) Long cursorId) {
-        redisMessageService.decreaseUnreadCountWithCursor(chatRoomId, cursorId - 1L);
+    public ResponseEntity<?> test() {
+        chatroomService.sendChatRoomInfo("2", 14L);
         return ResponseEntity.ok().build();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/controller/ChatController.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/controller/ChatController.java
@@ -4,6 +4,7 @@ import dutchiepay.backend.domain.chat.dto.ChatMessage;
 import dutchiepay.backend.domain.chat.dto.JoinChatRoomRequestDto;
 import dutchiepay.backend.domain.chat.dto.KickUserRequestDto;
 import dutchiepay.backend.domain.chat.service.ChatRoomService;
+import dutchiepay.backend.domain.chat.service.RedisMessageService;
 import dutchiepay.backend.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class ChatController {
     private final ChatRoomService chatroomService;
+    private final RedisMessageService redisMessageService;
 
     @MessageMapping("/chat/{chatRoomId}")
     public ChatMessage chat(@DestinationVariable String chatRoomId, ChatMessage message) {
@@ -75,5 +77,14 @@ public class ChatController {
                                                  @RequestParam(value = "cursor", required = false) String cursor,
                                                  @RequestParam(value = "limit") Long limit) {
         return ResponseEntity.ok(chatroomService.getChatRoomMessages(chatRoomId, cursor, limit));
+    }
+
+    @Operation(summary = "method 테스트")
+    @GetMapping("/test")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> test(@RequestParam(value = "chatRoomId") Long chatRoomId,
+                                  @RequestParam(value = "cursorId", required = false) Long cursorId) {
+        redisMessageService.decreaseUnreadCountWithCursor(chatRoomId, cursorId - 1L);
+        return ResponseEntity.ok().build();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/dto/CursorResponse.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/dto/CursorResponse.java
@@ -7,10 +7,12 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CursorResponse {
+    private String type;
     private Long cursor;
 
     public static CursorResponse of(Long cursor) {
         return CursorResponse.builder()
+                .type("cursor")
                 .cursor(cursor)
                 .build();
     }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/dto/MessageResponse.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/dto/MessageResponse.java
@@ -4,6 +4,7 @@ import dutchiepay.backend.entity.Message;
 import lombok.*;
 
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QChatRoomRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QChatRoomRepositoryImpl.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Repository
@@ -72,6 +73,8 @@ public class QChatRoomRepositoryImpl implements QChatRoomRepository {
             result.add(dto);
             count++;
         }
+
+        Collections.reverse(result);
 
         String nextCursor = tuple.size() > limit ? tuple.get(limit.intValue()).get(message.date) + tuple.get(limit.intValue()).get(message.messageId) : null;
         return GetMessageListResponseDto.builder()

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QMessageRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QMessageRepositoryImpl.java
@@ -1,7 +1,9 @@
 package dutchiepay.backend.domain.chat.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import dutchiepay.backend.entity.QChatRoom;
 import dutchiepay.backend.entity.QMessage;
+import dutchiepay.backend.entity.QUser;
 import dutchiepay.backend.entity.QUserChatRoom;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,21 +16,15 @@ public class QMessageRepositoryImpl implements QMessageRepository{
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    QMessage message = QMessage.message;
     QUserChatRoom userChatRoom = QUserChatRoom.userChatRoom;
 
     @Override
     public Long findCursorId(Long chatRoomId, Long userId) {
         return jpaQueryFactory
-                .select(message.messageId)
-                .from(message)
-                .join(userChatRoom)
-                .on(userChatRoom.chatroom.chatroomId.eq(chatRoomId)
+                .select(userChatRoom.lastMessageId)
+                .from(userChatRoom)
+                .where(userChatRoom.chatroom.chatroomId.eq(chatRoomId)
                         .and(userChatRoom.user.userId.eq(userId)))
-                .where(message.chatroom.chatroomId.eq(chatRoomId)
-                        .and(message.messageId.gt(userChatRoom.lastMessageId)))
-                .orderBy(message.messageId.asc())
-                .limit(1)
                 .fetchOne();
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QUserChatRoomRepository.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QUserChatRoomRepository.java
@@ -17,4 +17,6 @@ public interface QUserChatRoomRepository {
     List<GetChatRoomListResponseDto> getChatRoomList(User user);
 
     List<GetChatRoomUsersResponseDto> getChatRoomUsers(Long chatRoomId);
+
+    Boolean findByUserBanned(Long userId, Long chatRoomId);
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QUserChatRoomRepositoryImpl.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/repository/QUserChatRoomRepositoryImpl.java
@@ -115,40 +115,50 @@ public class QUserChatRoomRepositoryImpl implements QUserChatRoomRepository {
     }
 
     @Override
+    public Boolean findByUserBanned(Long userId, Long chatRoomId) {
+        return jpaQueryFactory
+                .select(userChatRoom.banned)
+                .from(userChatRoom)
+                .where(userChatRoom.user.userId.eq(userId)
+                        .and(userChatRoom.chatroom.chatroomId.eq(chatRoomId)))
+                .fetchOne();
+    }
+
+    @Override
     public void updateLastMessageLatestMessageId(long userId, Long chatRoomId) {
-//        Long latestMessageId = jpaQueryFactory
-//                .select(message.messageId.max())
-//                .from(message)
-//                .where(message.chatroom.chatroomId.eq(chatRoomId))
-//                .fetchOne();
-//
-//        if (latestMessageId != null) {
-//            jpaQueryFactory
-//                    .update(userChatRoom)
-//                    .set(userChatRoom.lastMessageId, latestMessageId)
-//                    .where(userChatRoom.user.userId.eq(userId)
-//                            .and(userChatRoom.chatroom.chatroomId.eq(chatRoomId)))
-//                    .execute();
-//        }
+        Long latestMessageId = jpaQueryFactory
+                .select(message.messageId.max())
+                .from(message)
+                .where(message.chatroom.chatroomId.eq(chatRoomId))
+                .fetchOne();
+
+        if (latestMessageId != null) {
+            jpaQueryFactory
+                    .update(userChatRoom)
+                    .set(userChatRoom.lastMessageId, latestMessageId)
+                    .where(userChatRoom.user.userId.eq(userId)
+                            .and(userChatRoom.chatroom.chatroomId.eq(chatRoomId)))
+                    .execute();
+        }
     }
 
     @Override
     public void updateLastMessageToUser(Long userId, Long chatRoomId) {
-//        Long latestMessageId = jpaQueryFactory
-//                .select(message.messageId)
-//                .from(message)
-//                .where(message.chatroom.chatroomId.eq(chatRoomId))
-//                .orderBy(message.messageId.desc())
-//                .limit(1)
-//                .fetchOne();
-//
-//        if (latestMessageId != null) {
-//            jpaQueryFactory
-//                    .update(userChatRoom)
-//                    .set(userChatRoom.lastMessageId, latestMessageId)
-//                    .where(userChatRoom.user.userId.eq(userId)
-//                            .and(userChatRoom.chatroom.chatroomId.eq(chatRoomId)))
-//                    .execute();
-//        }
+        Long latestMessageId = jpaQueryFactory
+                .select(message.messageId)
+                .from(message)
+                .where(message.chatroom.chatroomId.eq(chatRoomId))
+                .orderBy(message.messageId.desc())
+                .limit(1)
+                .fetchOne();
+
+        if (latestMessageId != null) {
+            jpaQueryFactory
+                    .update(userChatRoom)
+                    .set(userChatRoom.lastMessageId, latestMessageId)
+                    .where(userChatRoom.user.userId.eq(userId)
+                            .and(userChatRoom.chatroom.chatroomId.eq(chatRoomId)))
+                    .execute();
+        }
     }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
@@ -1,6 +1,5 @@
 package dutchiepay.backend.domain.chat.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dutchiepay.backend.domain.chat.dto.*;
 import dutchiepay.backend.domain.chat.exception.ChatErrorCode;
 import dutchiepay.backend.domain.chat.exception.ChatException;
@@ -11,8 +10,6 @@ import dutchiepay.backend.domain.community.service.PurchaseService;
 import dutchiepay.backend.entity.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.user.SimpSession;
 import org.springframework.messaging.simp.user.SimpSubscription;
@@ -26,8 +23,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -42,7 +37,7 @@ public class ChatRoomService {
     private final PurchaseService purchaseService;
     private final RedisMessageService redisMessageService;
 
-    private final String CHATROOM_PREFIX = "/sub/chat/";
+    private final String CHAT_ROOM_PREFIX = "/sub/chat/";
 
     /**
      * 게시글에 연결된 채팅방에 참여한다.
@@ -188,7 +183,7 @@ public class ChatRoomService {
         // 추후 상황에 맞게 isSendActivated를 변경한다.
         ChatRoomInfoResponse chatRoomInfo = ChatRoomInfoResponse.from(Long.valueOf(userId), chatRoom, true);
 
-        simpMessagingTemplate.convertAndSend(CHATROOM_PREFIX + chatRoomId, chatRoomInfo);
+        simpMessagingTemplate.convertAndSend(CHAT_ROOM_PREFIX + chatRoomId, chatRoomInfo);
     }
 
     /**
@@ -217,7 +212,7 @@ public class ChatRoomService {
         redisMessageService.saveMessage(chatRoomId, newMessage);
         updateLastMessageToAllSubscribers(chatRoomId, newMessage.getMessageId());
 
-        simpMessagingTemplate.convertAndSend(CHATROOM_PREFIX + chatRoomId, MessageResponse.of(newMessage));
+        simpMessagingTemplate.convertAndSend(CHAT_ROOM_PREFIX + chatRoomId, MessageResponse.of(newMessage));
     }
 
     /**
@@ -230,7 +225,7 @@ public class ChatRoomService {
     }
 
     private int getSubscribedUserCount(String chatRoomId) {
-        String destination = CHATROOM_PREFIX + chatRoomId;
+        String destination = CHAT_ROOM_PREFIX + chatRoomId;
         int count = 0;
 
         for (SimpUser user : simpUserRegistry.getUsers()) {
@@ -309,7 +304,7 @@ public class ChatRoomService {
         for (SimpUser user : simpUserRegistry.getUsers()) {
             for (SimpSession session : user.getSessions()) {
                 for (SimpSubscription subscription : session.getSubscriptions()) {
-                    if (subscription.getDestination().equals(CHATROOM_PREFIX + chatRoomId)) {
+                    if (subscription.getDestination().equals(CHAT_ROOM_PREFIX + chatRoomId)) {
                         userIds.add(Long.parseLong(user.getName()));
                     }
                 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
@@ -42,6 +42,8 @@ public class ChatRoomService {
     private final PurchaseService purchaseService;
     private final RedisMessageService redisMessageService;
 
+    private final String CHATROOM_PREFIX = "/sub/chat/";
+
     /**
      * 게시글에 연결된 채팅방에 참여한다.
      * @param user 유저
@@ -186,7 +188,7 @@ public class ChatRoomService {
         // 추후 상황에 맞게 isSendActivated를 변경한다.
         ChatRoomInfoResponse chatRoomInfo = ChatRoomInfoResponse.from(Long.valueOf(userId), chatRoom, true);
 
-        simpMessagingTemplate.convertAndSend("/sub/chat/" + chatRoomId, chatRoomInfo);
+        simpMessagingTemplate.convertAndSend(CHATROOM_PREFIX + chatRoomId, chatRoomInfo);
     }
 
     /**
@@ -215,7 +217,7 @@ public class ChatRoomService {
         redisMessageService.saveMessage(chatRoomId, newMessage);
         updateLastMessageToAllSubscribers(chatRoomId, newMessage.getMessageId());
 
-        simpMessagingTemplate.convertAndSend("/sub/chat/" + chatRoomId, MessageResponse.of(newMessage));
+        simpMessagingTemplate.convertAndSend(CHATROOM_PREFIX + chatRoomId, MessageResponse.of(newMessage));
     }
 
     /**
@@ -228,7 +230,7 @@ public class ChatRoomService {
     }
 
     private int getSubscribedUserCount(String chatRoomId) {
-        String destination = "/sub/chat/room/" + chatRoomId;
+        String destination = CHATROOM_PREFIX + chatRoomId;
         int count = 0;
 
         for (SimpUser user : simpUserRegistry.getUsers()) {
@@ -307,7 +309,7 @@ public class ChatRoomService {
         for (SimpUser user : simpUserRegistry.getUsers()) {
             for (SimpSession session : user.getSessions()) {
                 for (SimpSubscription subscription : session.getSubscriptions()) {
-                    if (subscription.getDestination().equals("/sub/chat/" + chatRoomId)) {
+                    if (subscription.getDestination().equals(CHATROOM_PREFIX + chatRoomId)) {
                         userIds.add(Long.parseLong(user.getName()));
                     }
                 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
@@ -286,18 +286,20 @@ public class ChatRoomService {
         return chatRoomRepository.findChatRoomMessages(chatRoomId, cursorDate, cursorMessageId, limit);
     }
 
-//    public void checkCursorId(Long chatRoomId, Long userId) {
-//        Long cursor = messageRepository.findCursorId(chatRoomId, userId);
-//
-//        if (cursor != null) {
-//            simpMessagingTemplate.convertAndSend("/sub/chat/room/read/" + chatRoomId, CursorResponse.of(cursor));
-//            userChatroomService.updateLastMessageToUser(userId, chatRoomId);
-//        } else {
-//            simpMessagingTemplate.convertAndSend("/sub/chat/room/read/" + chatRoomId, CursorResponse.of(0L));
-//            userChatroomService.updateLastMessageToUser(userId, chatRoomId);
-//        }
-//    }
-//
+    public void checkCursorId(Long chatRoomId, Long userId) {
+        Long cursor = messageRepository.findCursorId(chatRoomId, userId);
+
+        if (cursor != null) {
+            simpMessagingTemplate.convertAndSend(CHAT_ROOM_PREFIX + chatRoomId, CursorResponse.of(cursor));
+            userChatroomService.updateLastMessageToUser(userId, chatRoomId);
+        } else {
+            simpMessagingTemplate.convertAndSend(CHAT_ROOM_PREFIX + chatRoomId, CursorResponse.of(0L));
+            userChatroomService.updateLastMessageToUser(userId, chatRoomId);
+        }
+
+        redisMessageService.decreaseUnreadCountWithCursor(chatRoomId, cursor);
+    }
+
     private void updateLastMessageToAllSubscribers(String chatRoomId, Long messageId) {
         List<Long> userIds = new ArrayList<>();
 

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/ChatRoomService.java
@@ -37,7 +37,7 @@ public class ChatRoomService {
     private final PurchaseService purchaseService;
     private final RedisMessageService redisMessageService;
 
-    private final String CHAT_ROOM_PREFIX = "/sub/chat/";
+    private static final String CHAT_ROOM_PREFIX = "/sub/chat/";
 
     /**
      * 게시글에 연결된 채팅방에 참여한다.

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/MessageService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/MessageService.java
@@ -1,7 +1,5 @@
 package dutchiepay.backend.domain.chat.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dutchiepay.backend.domain.chat.dto.MessageResponse;
 import dutchiepay.backend.domain.chat.repository.MessageRepository;
 import dutchiepay.backend.entity.ChatRoom;
@@ -10,7 +8,6 @@ import dutchiepay.backend.entity.User;
 import dutchiepay.backend.entity.UserChatRoom;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
@@ -18,9 +15,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/RedisMessageService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/RedisMessageService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -88,6 +89,9 @@ public class RedisMessageService {
                 } else {
                     MessageResponse lastMessage = (MessageResponse) obj;
                     nextCursor = currentDate + lastMessage.getMessageId();
+
+                    Collections.reverse(totalDataList);
+
                     return GetMessageListResponseDto.builder()
                             .messages(totalDataList)
                             .cursor(nextCursor)
@@ -107,6 +111,8 @@ public class RedisMessageService {
 
         LocalDate date = LocalDate.parse(currentDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
         LocalDate previousDate = date.minusDays(1);
+
+        Collections.reverse(totalDataList);
 
         return GetMessageListResponseDto.builder()
                 .messages(totalDataList)

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/RedisMessageService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/RedisMessageService.java
@@ -30,8 +30,7 @@ public class RedisMessageService {
         redisTemplate.opsForZSet().add(redisKey, MessageResponse.of(message), message.getMessageId());
     }
 
-    public GetMessageListResponseDto
-    getMessageFromMemory(Long chatRoomId, String cursorDate, Long cursorMessageId, Long limit) {
+    public GetMessageListResponseDto getMessageFromMemory(Long chatRoomId, String cursorDate, Long cursorMessageId, Long limit) {
         List<MessageResponse> totalDataList = new ArrayList<>();
         String nextCursor;
         Long remainingLimit = limit;

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/UserChatroomService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/UserChatroomService.java
@@ -81,4 +81,8 @@ public class UserChatroomService {
     public void updateLastMessageToAllSubscribers(List<Long> userIds, long l, Long messageId) {
         userChatroomRepository.updateLastMessageToAllSubscribers(userIds, l, messageId);
     }
+
+    public void updateLastMessageToUser(Long userId, Long chatRoomId) {
+        userChatroomRepository.updateLastMessageToUser(userId, chatRoomId);
+    }
 }

--- a/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/UserChatroomService.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/domain/chat/service/UserChatroomService.java
@@ -35,10 +35,8 @@ public class UserChatroomService {
         chatRoom.joinUser();
     }
 
-    public boolean isBanned(User user, ChatRoom chatRoom) {
-        UserChatRoom userChatRoom = userChatroomRepository.findByUserAndChatroom(user, chatRoom);
-
-        return userChatRoom != null && userChatRoom.getBanned();
+    public boolean isBanned(Long userId, Long chatRoomId) {
+        return userChatroomRepository.findByUserBanned(userId, chatRoomId);
     }
 
     public UserChatRoom findByUserAndChatRoomId(User user, Long chatRoomId) {

--- a/DutchiePay/src/main/java/dutchiepay/backend/global/websocket/handler/StompEventListener.java
+++ b/DutchiePay/src/main/java/dutchiepay/backend/global/websocket/handler/StompEventListener.java
@@ -34,6 +34,7 @@ public class StompEventListener extends DefaultHandshakeHandler {
         String userId = accessor.getSessionAttributes().get("userId").toString();
         Long chatRoomId = Long.parseLong(destination.substring(destination.lastIndexOf("/") + 1));
 
+        chatRoomService.checkCursorId(chatRoomId, Long.valueOf(userId));
         chatRoomService.sendChatRoomInfo(userId, chatRoomId);
     }
 


### PR DESCRIPTION
### ⚡이슈 번호
resolve #234

---
### ✅ PR 종류
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 메시지 데이터 값 낮은 id값부터 리스트 상단에 오도록 변경
- 채팅방 구독 시점에서 유저가 마지막으로 체크한 messageId 값 저장(user_chatroom)
- 마지막 messageId값 이후의 데이터들의 unreadCount를 1씩 감소시킴(redis 데이터에서)
- 강퇴당한 채팅방에 대한 정보를 보내줄 때 isSendActivated를 false값으로 변경하여 전달
---
### 📖 참고 사항
- 이후 스케쥴링을 통해 redis에 저장된 메시지와 db와의 동기화를 하는 부분이 필요할 것으로 예상됌